### PR TITLE
Swift format for consistent whitespace

### DIFF
--- a/.swift-format.json
+++ b/.swift-format.json
@@ -1,0 +1,7 @@
+{
+  "indentation" : {
+    "tabs" : 1
+  },
+  "tabWidth" : 4,
+  "version" : 1
+}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For the most part, this library strives to be a straightforward version of the s
 
 ## Supported Features
 
-The LSP [specification](https://microsoft.github.io/language-server-protocol/specification) is large, and this library currently does not implement it all. The intention is to support the 3.x specification, but be as backwards-compatible as possible with pre-3.0 servers. 
+The LSP [specification](https://microsoft.github.io/language-server-protocol/specification) is large, and this library currently does not implement it all. The intention is to support the 3.x specification, but be as backwards-compatible as possible with pre-3.0 servers.
 
 | Message | Supported |
 | ----------|:---------:|
@@ -138,6 +138,14 @@ The LSP [specification](https://microsoft.github.io/language-server-protocol/spe
 I prefer collaboration, and would love to find ways to work together if you have a similar project.
 
 I prefer indentation with tabs for improved accessibility. But, I'd rather you use the system you want and make a PR than hesitate because of whitespace.
+
+## Swift format usage
+
+Using `swift-format` tool to format all source files, in-place:
+
+```sh
+swift-format --configuration .swift-format.json -r Sources -i
+```
 
 ## Suggestions or Feedback
 

--- a/Sources/LanguageServerProtocol/Additions/AsyncByteSequence.swift
+++ b/Sources/LanguageServerProtocol/Additions/AsyncByteSequence.swift
@@ -1,10 +1,11 @@
 import Foundation
 
 /// Converts a sequence of Data objects into a sequence of bytes.
-public struct AsyncByteSequence<Base> : AsyncSequence where Base : AsyncSequence, Base.Element == Data {
+public struct AsyncByteSequence<Base>: AsyncSequence
+where Base: AsyncSequence, Base.Element == Data {
 	public typealias Element = UInt8
 
-	public struct AsyncIterator : AsyncIteratorProtocol {
+	public struct AsyncIterator: AsyncIteratorProtocol {
 		private enum State {
 			case idle
 			case enumerating(Data, Data.Index)

--- a/Sources/LanguageServerProtocol/Additions/AsyncMessageFramingSequence.swift
+++ b/Sources/LanguageServerProtocol/Additions/AsyncMessageFramingSequence.swift
@@ -1,17 +1,18 @@
 import Foundation
 
 /// Sequence that reads data framed by the LSP base protocol specification.
-public struct AsyncMessageFramingSequence<Base> : AsyncSequence where Base : AsyncSequence, Base.Element == UInt8 {
+public struct AsyncMessageFramingSequence<Base>: AsyncSequence
+where Base: AsyncSequence, Base.Element == UInt8 {
 	public typealias Element = Data
 
-	public struct AsyncIterator : AsyncIteratorProtocol {
+	public struct AsyncIterator: AsyncIteratorProtocol {
 		private enum State {
 			case buffering
 			case expectingCR
 		}
 
 		private let linefeed: UInt8 = Character("\r").asciiValue!
-		private let newline: UInt8  = Character("\n").asciiValue!
+		private let newline: UInt8 = Character("\n").asciiValue!
 
 		private var iterator: Base.AsyncIterator
 

--- a/Sources/LanguageServerProtocol/Additions/MessageFraming.swift
+++ b/Sources/LanguageServerProtocol/Additions/MessageFraming.swift
@@ -25,7 +25,9 @@ public struct MessageFraming {
 		return (name, value)
 	}
 
-	public static func dataChannel(stdin: FileHandle, stdout: FileHandle, stderr: FileHandle, object: AnyObject?) -> DataChannel {
+	public static func dataChannel(
+		stdin: FileHandle, stdout: FileHandle, stderr: FileHandle, object: AnyObject?
+	) -> DataChannel {
 		DataChannel(writeHandler: { _ in }, dataSequence: AsyncStream<Data>(unfolding: { nil }))
 	}
 }

--- a/Sources/LanguageServerProtocol/Additions/MockServer.swift
+++ b/Sources/LanguageServerProtocol/Additions/MockServer.swift
@@ -29,26 +29,28 @@ public actor MockServer: Server {
 
 	public init() {
 		// this is annoying, but temporary
-#if compiler(>=5.9)
-		(self.notificationSequence, self.notificationContinuation) = NotificationSequence.makeStream()
-		(self.requestSequence, self.requestContinuation) = RequestSequence.makeStream()
-		(self.sentMessageSequence, self.sentMessageContinuation) = ClientMessageSequence.makeStream()
-#else
-		var escapedNoteContinuation: NotificationSequence.Continuation?
+		#if compiler(>=5.9)
+			(self.notificationSequence, self.notificationContinuation) =
+				NotificationSequence.makeStream()
+			(self.requestSequence, self.requestContinuation) = RequestSequence.makeStream()
+			(self.sentMessageSequence, self.sentMessageContinuation) =
+				ClientMessageSequence.makeStream()
+		#else
+			var escapedNoteContinuation: NotificationSequence.Continuation?
 
-		self.notificationSequence = NotificationSequence { escapedNoteContinuation = $0 }
-		self.notificationContinuation = escapedNoteContinuation!
+			self.notificationSequence = NotificationSequence { escapedNoteContinuation = $0 }
+			self.notificationContinuation = escapedNoteContinuation!
 
-		var escapedRequestContinuation: RequestSequence.Continuation?
+			var escapedRequestContinuation: RequestSequence.Continuation?
 
-		self.requestSequence = RequestSequence { escapedRequestContinuation = $0 }
-		self.requestContinuation = escapedRequestContinuation!
+			self.requestSequence = RequestSequence { escapedRequestContinuation = $0 }
+			self.requestContinuation = escapedRequestContinuation!
 
-		var escapedSentContinuation: ClientMessageSequence.Continuation?
+			var escapedSentContinuation: ClientMessageSequence.Continuation?
 
-		self.sentMessageSequence = ClientMessageSequence { escapedSentContinuation = $0 }
-		self.sentMessageContinuation = escapedSentContinuation!
-#endif
+			self.sentMessageSequence = ClientMessageSequence { escapedSentContinuation = $0 }
+			self.sentMessageContinuation = escapedSentContinuation!
+		#endif
 	}
 
 	deinit {
@@ -61,7 +63,8 @@ public actor MockServer: Server {
 		sentMessageContinuation.yield(.notification(notif))
 	}
 
-	public func sendRequest<Response>(_ request: ClientRequest) async throws -> Response where Response : Decodable, Response : Sendable {
+	public func sendRequest<Response>(_ request: ClientRequest) async throws -> Response
+	where Response: Decodable, Response: Sendable {
 		sentMessageContinuation.yield(.request(request))
 
 		if mockResponses.isEmpty {
@@ -95,7 +98,8 @@ extension MockServer {
 	}
 
 	/// Simulate a server response.
-	public func sendMockResponse<Response>(_ response: Response) throws where Response : Encodable, Response : Sendable {
+	public func sendMockResponse<Response>(_ response: Response) throws
+	where Response: Encodable, Response: Sendable {
 		let data = try JSONEncoder().encode(response)
 
 		sendMockResponse(data)

--- a/Sources/LanguageServerProtocol/Additions/NSRegularExpression+Matching.swift
+++ b/Sources/LanguageServerProtocol/Additions/NSRegularExpression+Matching.swift
@@ -1,29 +1,31 @@
 import Foundation
 
 extension NSRegularExpression {
-    func matches(inFullString string: String, options: NSRegularExpression.MatchingOptions = []) -> [NSTextCheckingResult] {
-        let range = NSMakeRange(0, string.utf16.count)
+	func matches(inFullString string: String, options: NSRegularExpression.MatchingOptions = [])
+		-> [NSTextCheckingResult]
+	{
+		let range = NSMakeRange(0, string.utf16.count)
 
-        return matches(in: string, options: options, range: range)
-    }
+		return matches(in: string, options: options, range: range)
+	}
 }
 
 extension NSTextCheckingResult {
-    func range(at index: Int, in string: String) -> Range<String.Index>? {
-        let nsRange = range(at: index)
+	func range(at index: Int, in string: String) -> Range<String.Index>? {
+		let nsRange = range(at: index)
 
-        return Range(nsRange, in: string)
-    }
+		return Range(nsRange, in: string)
+	}
 
-    func stringValue(at index: Int, in string: String) -> Substring? {
-        guard let captureRange = range(at: index, in: string) else {
-            return nil
-        }
+	func stringValue(at index: Int, in string: String) -> Substring? {
+		guard let captureRange = range(at: index, in: string) else {
+			return nil
+		}
 
-        return string[captureRange]
-    }
+		return string[captureRange]
+	}
 
-    func intValue(at index: Int, in string: String) -> Int? {
-        return stringValue(at: index, in: string).flatMap { Int($0) }
-    }
+	func intValue(at index: Int, in string: String) -> Int? {
+		return stringValue(at: index, in: string).flatMap { Int($0) }
+	}
 }

--- a/Sources/LanguageServerProtocol/Additions/Server.swift
+++ b/Sources/LanguageServerProtocol/Additions/Server.swift
@@ -11,7 +11,8 @@ public protocol Server {
 	var requestSequence: RequestSequence { get }
 
 	func sendNotification(_ notif: ClientNotification) async throws
-	func sendRequest<Response: Decodable & Sendable>(_ request: ClientRequest) async throws -> Response
+	func sendRequest<Response: Decodable & Sendable>(_ request: ClientRequest) async throws
+		-> Response
 }
 
 extension Server {
@@ -20,242 +21,287 @@ extension Server {
 	}
 }
 
-public extension Server {
-	func initialize(params: InitializeParams) async throws -> InitializationResponse {
+extension Server {
+	public func initialize(params: InitializeParams) async throws -> InitializationResponse {
 		return try await sendRequest(.initialize(params))
 	}
 
-	func initialized(params: InitializedParams) async throws {
+	public func initialized(params: InitializedParams) async throws {
 		try await sendNotification(.initialized(params))
 	}
 
-	func shutdown() async throws {
+	public func shutdown() async throws {
 		try await sendRequestWithErrorOnlyResult(.shutdown)
 	}
 
-	func exit() async throws {
+	public func exit() async throws {
 		try await sendNotification(.exit)
 	}
 
-    func cancelRequest(params: CancelParams) async throws {
-        try await sendNotification(.protocolCancelRequest(params))
-    }
+	public func cancelRequest(params: CancelParams) async throws {
+		try await sendNotification(.protocolCancelRequest(params))
+	}
 
-    func setTrace(params: SetTraceParams) async throws {
-        try await sendNotification(.protocolSetTrace(params))
-    }
+	public func setTrace(params: SetTraceParams) async throws {
+		try await sendNotification(.protocolSetTrace(params))
+	}
 
-    func didOpenTextDocument(params: DidOpenTextDocumentParams) async throws {
+	public func didOpenTextDocument(params: DidOpenTextDocumentParams) async throws {
 		try await sendNotification(.didOpenTextDocument(params))
-    }
+	}
 
-    func didChangeTextDocument(params: DidChangeTextDocumentParams) async throws {
+	public func didChangeTextDocument(params: DidChangeTextDocumentParams) async throws {
 		try await sendNotification(.didChangeTextDocument(params))
-    }
+	}
 
-    func didCloseTextDocument(params: DidCloseTextDocumentParams) async throws {
+	public func didCloseTextDocument(params: DidCloseTextDocumentParams) async throws {
 		try await sendNotification(.didCloseTextDocument(params))
-    }
+	}
 
-    func willSaveTextDocument(params: WillSaveTextDocumentParams) async throws {
+	public func willSaveTextDocument(params: WillSaveTextDocumentParams) async throws {
 		try await sendNotification(.willSaveTextDocument(params))
-    }
+	}
 
-	func willSaveWaitUntilTextDocument(params: WillSaveTextDocumentParams) async throws -> WillSaveWaitUntilResponse {
+	public func willSaveWaitUntilTextDocument(params: WillSaveTextDocumentParams) async throws
+		-> WillSaveWaitUntilResponse
+	{
 		try await sendRequest(.willSaveWaitUntilTextDocument(params))
 	}
 
-    func didSaveTextDocument(params: DidSaveTextDocumentParams) async throws {
+	public func didSaveTextDocument(params: DidSaveTextDocumentParams) async throws {
 		try await sendNotification(.didSaveTextDocument(params))
-    }
+	}
 
-    func didChangeWatchedFiles(params: DidChangeWatchedFilesParams) async throws {
-        try await sendNotification(.didChangeWatchedFiles(params))
-    }
+	public func didChangeWatchedFiles(params: DidChangeWatchedFilesParams) async throws {
+		try await sendNotification(.didChangeWatchedFiles(params))
+	}
 
-	func callHierarchyIncomingCalls(params: CallHierarchyIncomingCallsParams) async throws -> CallHierarchyIncomingCallsResponse {
+	public func callHierarchyIncomingCalls(params: CallHierarchyIncomingCallsParams) async throws
+		-> CallHierarchyIncomingCallsResponse
+	{
 		try await sendRequest(.callHierarchyIncomingCalls(params))
 	}
 
-	func callHierarchyOutgoingCalls(params: CallHierarchyOutgoingCallsParams) async throws -> CallHierarchyOutgoingCallsResponse {
+	public func callHierarchyOutgoingCalls(params: CallHierarchyOutgoingCallsParams) async throws
+		-> CallHierarchyOutgoingCallsResponse
+	{
 		try await sendRequest(.callHierarchyOutgoingCalls(params))
 	}
 
-    func completion(params: CompletionParams) async throws -> CompletionResponse {
-        try await sendRequest(.completion(params))
-    }
+	public func completion(params: CompletionParams) async throws -> CompletionResponse {
+		try await sendRequest(.completion(params))
+	}
 
-    func hover(params: TextDocumentPositionParams) async throws -> HoverResponse {
-        try await sendRequest(.hover(params))
-    }
+	public func hover(params: TextDocumentPositionParams) async throws -> HoverResponse {
+		try await sendRequest(.hover(params))
+	}
 
-    func signatureHelp(params: TextDocumentPositionParams) async throws -> SignatureHelpResponse {
-        try await sendRequest(.signatureHelp(params))
-    }
+	public func signatureHelp(params: TextDocumentPositionParams) async throws
+		-> SignatureHelpResponse
+	{
+		try await sendRequest(.signatureHelp(params))
+	}
 
-    func declaration(params: TextDocumentPositionParams) async throws -> DeclarationResponse {
-        try await sendRequest(.declaration(params))
-    }
+	public func declaration(params: TextDocumentPositionParams) async throws -> DeclarationResponse
+	{
+		try await sendRequest(.declaration(params))
+	}
 
-    func definition(params: TextDocumentPositionParams) async throws -> DefinitionResponse {
-        try await sendRequest(.definition(params))
-    }
+	public func definition(params: TextDocumentPositionParams) async throws -> DefinitionResponse {
+		try await sendRequest(.definition(params))
+	}
 
-    func typeDefinition(params: TextDocumentPositionParams) async throws -> TypeDefinitionResponse {
-        try await sendRequest(.typeDefinition(params))
-    }
+	public func typeDefinition(params: TextDocumentPositionParams) async throws
+		-> TypeDefinitionResponse
+	{
+		try await sendRequest(.typeDefinition(params))
+	}
 
-    func implementation(params: TextDocumentPositionParams) async throws -> ImplementationResponse {
-        try await sendRequest(.implementation(params))
-    }
+	public func implementation(params: TextDocumentPositionParams) async throws
+		-> ImplementationResponse
+	{
+		try await sendRequest(.implementation(params))
+	}
 
-    func documentSymbol(params: DocumentSymbolParams) async throws -> DocumentSymbolResponse {
-        try await sendRequest(.documentSymbol(params))
-    }
+	public func documentSymbol(params: DocumentSymbolParams) async throws -> DocumentSymbolResponse
+	{
+		try await sendRequest(.documentSymbol(params))
+	}
 
-    func prepareCallHierarchy(params: CallHierarchyPrepareParams) async throws -> CallHierarchyPrepareResponse {
-        try await sendRequest(.prepareCallHierarchy(params))
-    }
+	public func prepareCallHierarchy(params: CallHierarchyPrepareParams) async throws
+		-> CallHierarchyPrepareResponse
+	{
+		try await sendRequest(.prepareCallHierarchy(params))
+	}
 
-    func prepareRename(params: PrepareRenameParams) async throws -> PrepareRenameResponse {
-        try await sendRequest(.prepareRename(params))
-    }
+	public func prepareRename(params: PrepareRenameParams) async throws -> PrepareRenameResponse {
+		try await sendRequest(.prepareRename(params))
+	}
 
-    func rename(params: RenameParams) async throws -> RenameResponse {
-        try await sendRequest(.rename(params))
-    }
+	public func rename(params: RenameParams) async throws -> RenameResponse {
+		try await sendRequest(.rename(params))
+	}
 
-    func formatting(params: DocumentFormattingParams) async throws -> FormattingResult {
-        try await sendRequest(.formatting(params))
-    }
+	public func formatting(params: DocumentFormattingParams) async throws -> FormattingResult {
+		try await sendRequest(.formatting(params))
+	}
 
-    func rangeFormatting(params: DocumentRangeFormattingParams) async throws -> FormattingResult {
-        try await sendRequest(.rangeFormatting(params))
-    }
+	public func rangeFormatting(params: DocumentRangeFormattingParams) async throws
+		-> FormattingResult
+	{
+		try await sendRequest(.rangeFormatting(params))
+	}
 
-    func onTypeFormatting(params: DocumentOnTypeFormattingParams) async throws -> FormattingResult {
-        try await sendRequest(.onTypeFormatting(params))
-    }
+	public func onTypeFormatting(params: DocumentOnTypeFormattingParams) async throws
+		-> FormattingResult
+	{
+		try await sendRequest(.onTypeFormatting(params))
+	}
 
-    func references(params: ReferenceParams) async throws -> ReferenceResponse {
-        try await sendRequest(.references(params))
-    }
+	public func references(params: ReferenceParams) async throws -> ReferenceResponse {
+		try await sendRequest(.references(params))
+	}
 
-    func foldingRange(params: FoldingRangeParams) async throws -> FoldingRangeResponse {
-        try await sendRequest(.foldingRange(params))
-    }
+	public func foldingRange(params: FoldingRangeParams) async throws -> FoldingRangeResponse {
+		try await sendRequest(.foldingRange(params))
+	}
 
-    func semanticTokensFull(params: SemanticTokensParams) async throws -> SemanticTokensResponse {
-        try await sendRequest(.semanticTokensFull(params))
-    }
+	public func semanticTokensFull(params: SemanticTokensParams) async throws
+		-> SemanticTokensResponse
+	{
+		try await sendRequest(.semanticTokensFull(params))
+	}
 
-    func semanticTokensFullDelta(params: SemanticTokensDeltaParams) async throws -> SemanticTokensDeltaResponse {
-        try await sendRequest(.semanticTokensFullDelta(params))
-    }
+	public func semanticTokensFullDelta(params: SemanticTokensDeltaParams) async throws
+		-> SemanticTokensDeltaResponse
+	{
+		try await sendRequest(.semanticTokensFullDelta(params))
+	}
 
-    func semanticTokensRange(params: SemanticTokensRangeParams) async throws -> SemanticTokensResponse {
-        try await sendRequest(.semanticTokensRange(params))
-    }
+	public func semanticTokensRange(params: SemanticTokensRangeParams) async throws
+		-> SemanticTokensResponse
+	{
+		try await sendRequest(.semanticTokensRange(params))
+	}
 
-
-    func customRequest<Response: Decodable & Sendable>(method: String, params: LSPAny) async throws -> Response {
-        try await sendRequest(.custom(method, params))
-    }
+	public func customRequest<Response: Decodable & Sendable>(method: String, params: LSPAny)
+		async throws -> Response
+	{
+		try await sendRequest(.custom(method, params))
+	}
 }
 
 // Workspace notifications
-public extension Server {
-    func didChangeWorkspaceFolders(params: DidChangeWorkspaceFoldersParams) async throws {
-        try await sendNotification(.workspaceDidChangeWorkspaceFolders(params))
-    }
+extension Server {
+	public func didChangeWorkspaceFolders(params: DidChangeWorkspaceFoldersParams) async throws {
+		try await sendNotification(.workspaceDidChangeWorkspaceFolders(params))
+	}
 
-    func didChangeConfiguration(params: DidChangeConfigurationParams) async throws {
+	public func didChangeConfiguration(params: DidChangeConfigurationParams) async throws {
 		try await sendNotification(.workspaceDidChangeConfiguration(params))
-    }
+	}
 
-    func didCreateFiles(params: CreateFilesParams) async throws {
+	public func didCreateFiles(params: CreateFilesParams) async throws {
 		try await sendNotification(.workspaceDidCreateFiles(params))
-    }
+	}
 
-    func didRenameFiles(params: RenameFilesParams) async throws {
+	public func didRenameFiles(params: RenameFilesParams) async throws {
 		try await sendNotification(.workspaceDidRenameFiles(params))
-    }
+	}
 
-    func didDeleteFiles(params: DeleteFilesParams) async throws {
+	public func didDeleteFiles(params: DeleteFilesParams) async throws {
 		try await sendNotification(.workspaceDidDeleteFiles(params))
-    }
+	}
 }
 
 // Workspace Requests
-public extension Server {
-    func willCreateFiles(params: CreateFilesParams) async throws -> WorkspaceWillCreateFilesResponse {
-        try await sendRequest(.workspaceWillCreateFiles(params))
-    }
+extension Server {
+	public func willCreateFiles(params: CreateFilesParams) async throws
+		-> WorkspaceWillCreateFilesResponse
+	{
+		try await sendRequest(.workspaceWillCreateFiles(params))
+	}
 
-    func willRenameFiles(params: RenameFilesParams) async throws -> WorkspaceWillRenameFilesResponse {
-        try await sendRequest(.workspaceWillRenameFiles(params))
-    }
+	public func willRenameFiles(params: RenameFilesParams) async throws
+		-> WorkspaceWillRenameFilesResponse
+	{
+		try await sendRequest(.workspaceWillRenameFiles(params))
+	}
 
-    func willDeleteFiles(params: DeleteFilesParams) async throws -> WorkspaceWillDeleteFilesResponse {
-        try await sendRequest(.workspaceWillDeleteFiles(params))
-    }
+	public func willDeleteFiles(params: DeleteFilesParams) async throws
+		-> WorkspaceWillDeleteFilesResponse
+	{
+		try await sendRequest(.workspaceWillDeleteFiles(params))
+	}
 
-    func executeCommand(params: ExecuteCommandParams) async throws -> ExecuteCommandResponse {
-        try await sendRequest(.workspaceExecuteCommand(params))
-    }
+	public func executeCommand(params: ExecuteCommandParams) async throws -> ExecuteCommandResponse
+	{
+		try await sendRequest(.workspaceExecuteCommand(params))
+	}
 
-    func workspaceSymbol(params: WorkspaceSymbolParams) async throws -> WorkspaceSymbolResponse {
-        try await sendRequest(.workspaceSymbol(params))
-    }
+	public func workspaceSymbol(params: WorkspaceSymbolParams) async throws
+		-> WorkspaceSymbolResponse
+	{
+		try await sendRequest(.workspaceSymbol(params))
+	}
 
-    func workspaceSymbolResolve(params: WorkspaceSymbol) async throws -> WorkspaceSymbolResponse {
-        try await sendRequest(.workspaceSymbolResolve(params))
-    }
+	public func workspaceSymbolResolve(params: WorkspaceSymbol) async throws
+		-> WorkspaceSymbolResponse
+	{
+		try await sendRequest(.workspaceSymbolResolve(params))
+	}
 }
 
 // Language Features
-public extension Server {
-    func documentHighlight(params: DocumentHighlightParams) async throws -> DocumentHighlightResponse {
-        try await sendRequest(.documentHighlight(params))
-    }
+extension Server {
+	public func documentHighlight(params: DocumentHighlightParams) async throws
+		-> DocumentHighlightResponse
+	{
+		try await sendRequest(.documentHighlight(params))
+	}
 
-	func codeAction(params: CodeActionParams) async throws -> CodeActionResponse {
+	public func codeAction(params: CodeActionParams) async throws -> CodeActionResponse {
 		try await sendRequest(.codeAction(params))
 	}
 
-	func codeActionResolve(params: CodeAction) async throws -> CodeAction {
+	public func codeActionResolve(params: CodeAction) async throws -> CodeAction {
 		try await sendRequest(.codeActionResolve(params))
 	}
 
-    func codeLens(params: CodeLensParams) async throws -> CodeLensResponse {
-        try await sendRequest(.codeLens(params))
-    }
+	public func codeLens(params: CodeLensParams) async throws -> CodeLensResponse {
+		try await sendRequest(.codeLens(params))
+	}
 
-    func codeLensResolve(params: CodeLens) async throws -> CodeLensResolveResponse {
-        try await sendRequest(.codeLensResolve(params))
-    }
+	public func codeLensResolve(params: CodeLens) async throws -> CodeLensResolveResponse {
+		try await sendRequest(.codeLensResolve(params))
+	}
 
-	func diagnostics(params: DocumentDiagnosticParams) async throws -> DocumentDiagnosticReport {
+	public func diagnostics(params: DocumentDiagnosticParams) async throws
+		-> DocumentDiagnosticReport
+	{
 		try await sendRequest(.diagnostics(params))
 	}
-	
-    func selectionRange(params: SelectionRangeParams) async throws -> SelectionRangeResponse {
-        try await sendRequest(.selectionRange(params))
-    }
 
-    func documentLink(params: DocumentLinkParams) async throws -> DocumentLinkResponse {
-        try await sendRequest(.documentLink(params))
-    }
+	public func selectionRange(params: SelectionRangeParams) async throws -> SelectionRangeResponse
+	{
+		try await sendRequest(.selectionRange(params))
+	}
 
-    func documentLinkResolve(params: DocumentLink) async throws -> DocumentLink {
-        try await sendRequest(.documentLinkResolve(params))
-    }
+	public func documentLink(params: DocumentLinkParams) async throws -> DocumentLinkResponse {
+		try await sendRequest(.documentLink(params))
+	}
 
-    func documentColor(params: DocumentColorParams) async throws -> DocumentColorResponse {
-        try await sendRequest(.documentColor(params))
-    }
+	public func documentLinkResolve(params: DocumentLink) async throws -> DocumentLink {
+		try await sendRequest(.documentLinkResolve(params))
+	}
 
-    func colorPresentation(params: ColorPresentationParams) async throws -> ColorPresentationResponse {
-        try await sendRequest(.colorPresentation(params))
-    }
+	public func documentColor(params: DocumentColorParams) async throws -> DocumentColorResponse {
+		try await sendRequest(.documentColor(params))
+	}
+
+	public func colorPresentation(params: ColorPresentationParams) async throws
+		-> ColorPresentationResponse
+	{
+		try await sendRequest(.colorPresentation(params))
+	}
 }

--- a/Sources/LanguageServerProtocol/Additions/ServerCapabilities+Extensions.swift
+++ b/Sources/LanguageServerProtocol/Additions/ServerCapabilities+Extensions.swift
@@ -1,133 +1,138 @@
 import Foundation
 
-public extension Registration {
-    var requestMethod: ClientRequest.Method? {
-        return ClientRequest.Method(rawValue: method)
-    }
+extension Registration {
+	public var requestMethod: ClientRequest.Method? {
+		return ClientRequest.Method(rawValue: method)
+	}
 
-    var notificationMethod: ClientNotification.Method? {
-        return ClientNotification.Method(rawValue: method)
-    }
+	public var notificationMethod: ClientNotification.Method? {
+		return ClientNotification.Method(rawValue: method)
+	}
 }
 
-public extension Unregistration {
-    var requestMethod: ClientRequest.Method? {
-        return ClientRequest.Method(rawValue: method)
-    }
+extension Unregistration {
+	public var requestMethod: ClientRequest.Method? {
+		return ClientRequest.Method(rawValue: method)
+	}
 
-    var notificationMethod: ClientNotification.Method? {
-        return ClientNotification.Method(rawValue: method)
-    }
+	public var notificationMethod: ClientNotification.Method? {
+		return ClientNotification.Method(rawValue: method)
+	}
 }
 
-public extension ServerCapabilities {
-    mutating func applyRegistrations(_ registrations: [Registration]) throws {
-        try registrations.forEach({ try applyRegistration($0) })
-    }
+extension ServerCapabilities {
+	public mutating func applyRegistrations(_ registrations: [Registration]) throws {
+		try registrations.forEach({ try applyRegistration($0) })
+	}
 
-    mutating func applyRegistration(_ registration: Registration) throws {
-        switch registration.requestMethod {
-        case .textDocumentSemanticTokens:
-            let data = try JSONEncoder().encode(registration.registerOptions)
-            let options = try JSONDecoder().decode(TwoTypeOption<SemanticTokensOptions, SemanticTokensRegistrationOptions>.self, from: data)
+	public mutating func applyRegistration(_ registration: Registration) throws {
+		switch registration.requestMethod {
+		case .textDocumentSemanticTokens:
+			let data = try JSONEncoder().encode(registration.registerOptions)
+			let options = try JSONDecoder().decode(
+				TwoTypeOption<SemanticTokensOptions, SemanticTokensRegistrationOptions>.self,
+				from: data)
 
-            self.semanticTokensProvider = options
-            return
-				case .textDocumentCompletion:
-					let data = try JSONEncoder().encode(registration.registerOptions)
-					let options = try JSONDecoder().decode(CompletionOptions.self, from: data)
+			self.semanticTokensProvider = options
+			return
+		case .textDocumentCompletion:
+			let data = try JSONEncoder().encode(registration.registerOptions)
+			let options = try JSONDecoder().decode(CompletionOptions.self, from: data)
 
-					self.completionProvider = options
-					return
-				default:
-            break
-        }
+			self.completionProvider = options
+			return
+		default:
+			break
+		}
 
-        switch registration.notificationMethod {
-        case .workspaceDidChangeWatchedFiles:
-            break
-        default:
-            break
-        }
-    }
+		switch registration.notificationMethod {
+		case .workspaceDidChangeWatchedFiles:
+			break
+		default:
+			break
+		}
+	}
 
-    mutating func applyUnregistrations(_ unregistrations: [Unregistration]) throws {
-        try unregistrations.forEach({ try applyUnregistration($0) })
-    }
+	public mutating func applyUnregistrations(_ unregistrations: [Unregistration]) throws {
+		try unregistrations.forEach({ try applyUnregistration($0) })
+	}
 
-    mutating func applyUnregistration(_ unregistration: Unregistration) throws {
-        switch unregistration.requestMethod {
-        case .textDocumentSemanticTokens:
-            self.semanticTokensProvider = nil
-            return
-				case .textDocumentCompletion:
-						self.completionProvider = nil
-						return
-        default:
-            break
-        }
+	public mutating func applyUnregistration(_ unregistration: Unregistration) throws {
+		switch unregistration.requestMethod {
+		case .textDocumentSemanticTokens:
+			self.semanticTokensProvider = nil
+			return
+		case .textDocumentCompletion:
+			self.completionProvider = nil
+			return
+		default:
+			break
+		}
 
-        switch unregistration.notificationMethod {
-        case .workspaceDidChangeWatchedFiles:
-            break
-        default:
-            break
-        }
-    }
+		switch unregistration.notificationMethod {
+		case .workspaceDidChangeWatchedFiles:
+			break
+		default:
+			break
+		}
+	}
 }
 
-public extension TwoTypeOption where T == TextDocumentSyncOptions, U == TextDocumentSyncKind {
-     var effectiveOptions: TextDocumentSyncOptions {
-        switch self {
-        case .optionA(let value):
-            return value
-        case .optionB(let changeKind):
-            return TextDocumentSyncOptions(openClose: false, change: changeKind, willSave: false, willSaveWaitUntil: false, save: nil)
-        }
-    }
+extension TwoTypeOption where T == TextDocumentSyncOptions, U == TextDocumentSyncKind {
+	public var effectiveOptions: TextDocumentSyncOptions {
+		switch self {
+		case .optionA(let value):
+			return value
+		case .optionB(let changeKind):
+			return TextDocumentSyncOptions(
+				openClose: false, change: changeKind, willSave: false, willSaveWaitUntil: false,
+				save: nil)
+		}
+	}
 }
 
-public extension TwoTypeOption where T == SemanticTokensOptions, U == SemanticTokensRegistrationOptions {
-    var effectiveOptions: SemanticTokensOptions {
-        switch self {
-        case .optionA(let options):
-            return options
-        case .optionB(let registrationOptions):
-            return SemanticTokensOptions(workDoneProgress: registrationOptions.workDoneProgress,
-                                         legend: registrationOptions.legend,
-                                         range: registrationOptions.range,
-                                         full: registrationOptions.full)
-        }
-    }
+extension TwoTypeOption where T == SemanticTokensOptions, U == SemanticTokensRegistrationOptions {
+	public var effectiveOptions: SemanticTokensOptions {
+		switch self {
+		case .optionA(let options):
+			return options
+		case .optionB(let registrationOptions):
+			return SemanticTokensOptions(
+				workDoneProgress: registrationOptions.workDoneProgress,
+				legend: registrationOptions.legend,
+				range: registrationOptions.range,
+				full: registrationOptions.full)
+		}
+	}
 }
 
-public extension SemanticTokensClientCapabilities.Requests.RangeOption {
-    var supported: Bool {
-        switch self {
-        case .optionA(let value):
-            return value
-        case .optionB(_):
-            return true
-        }
-    }
+extension SemanticTokensClientCapabilities.Requests.RangeOption {
+	public var supported: Bool {
+		switch self {
+		case .optionA(let value):
+			return value
+		case .optionB(_):
+			return true
+		}
+	}
 }
 
-public extension SemanticTokensClientCapabilities.Requests.FullOption {
-    var supported: Bool {
-        switch self {
-        case .optionA(let value):
-            return value
-        case .optionB(_):
-            return true
-        }
-    }
+extension SemanticTokensClientCapabilities.Requests.FullOption {
+	public var supported: Bool {
+		switch self {
+		case .optionA(let value):
+			return value
+		case .optionB(_):
+			return true
+		}
+	}
 
-    var deltaSupported: Bool {
-        switch self {
-        case .optionA(_):
-            return false
-        case .optionB(let full):
-            return full.delta ?? false
-        }
-    }
+	public var deltaSupported: Bool {
+		switch self {
+		case .optionA(_):
+			return false
+		case .optionB(let full):
+			return full.delta ?? false
+		}
+	}
 }

--- a/Sources/LanguageServerProtocol/Additions/Snippet.swift
+++ b/Sources/LanguageServerProtocol/Additions/Snippet.swift
@@ -1,165 +1,165 @@
 import Foundation
 
 public struct Snippet {
-    public enum Element: Equatable {
-        case text(String)
-        case tabstop(Int)
-        case placeholder(Int, String)
-        case choice(Int, [String])
-        case variable(String, String)
-        case variableTransform(String, String, String, String)
-    }
+	public enum Element: Equatable {
+		case text(String)
+		case tabstop(Int)
+		case placeholder(Int, String)
+		case choice(Int, [String])
+		case variable(String, String)
+		case variableTransform(String, String, String, String)
+	}
 
-    public let value: String
+	public let value: String
 
-    public init(value: String) {
-        self.value = value
-    }
+	public init(value: String) {
+		self.value = value
+	}
 }
 
 extension Snippet {
-    public var elementRanges: [NSRange] {
-        let regex = try! NSRegularExpression(pattern: #"\$(\w+|\{([^$]+)\})"#)
+	public var elementRanges: [NSRange] {
+		let regex = try! NSRegularExpression(pattern: #"\$(\w+|\{([^$]+)\})"#)
 
-        return regex.matches(inFullString: value).map({ $0.range })
-    }
+		return regex.matches(inFullString: value).map({ $0.range })
+	}
 
-    public func enumerateElements(block: (Element) -> Void) {
-        let ranges = elementRanges
+	public func enumerateElements(block: (Element) -> Void) {
+		let ranges = elementRanges
 
-        var location = 0
+		var location = 0
 
-        for range in ranges {
-            let textRange = NSMakeRange(location, range.location - location)
+		for range in ranges {
+			let textRange = NSMakeRange(location, range.location - location)
 
-            if let v = subvalue(for: textRange) {
-                block(textElement(for: v))
-            }
+			if let v = subvalue(for: textRange) {
+				block(textElement(for: v))
+			}
 
-            if let content = subvalue(for: range) {
-                if let elem = element(for: content) {
-                    block(elem)
-                }
-            }
+			if let content = subvalue(for: range) {
+				if let elem = element(for: content) {
+					block(elem)
+				}
+			}
 
-            location = NSMaxRange(range)
-        }
+			location = NSMaxRange(range)
+		}
 
-        let lastTextRange = NSMakeRange(location, value.utf16.count - location)
+		let lastTextRange = NSMakeRange(location, value.utf16.count - location)
 
-        if let v = subvalue(for: lastTextRange) {
-            block(textElement(for: v))
-        }
-    }
+		if let v = subvalue(for: lastTextRange) {
+			block(textElement(for: v))
+		}
+	}
 
-    public var elements: [Snippet.Element] {
-        var list = [Snippet.Element]()
+	public var elements: [Snippet.Element] {
+		var list = [Snippet.Element]()
 
-        enumerateElements { (element) in
-            list.append(element)
-        }
+		enumerateElements { (element) in
+			list.append(element)
+		}
 
-        return list
-    }
+		return list
+	}
 
-    private func subvalue(for range: NSRange) -> String? {
-        if range.length == 0 {
-            return nil
-        }
+	private func subvalue(for range: NSRange) -> String? {
+		if range.length == 0 {
+			return nil
+		}
 
-        guard let stringRange = Range(range, in: value) else {
-            return nil
-        }
+		guard let stringRange = Range(range, in: value) else {
+			return nil
+		}
 
-        return String(value[stringRange])
-    }
+		return String(value[stringRange])
+	}
 }
 
 extension Snippet {
-    private func element(for content: String) -> Element? {
-        if let elem = tabstop(for: content) {
-            return elem
-        }
+	private func element(for content: String) -> Element? {
+		if let elem = tabstop(for: content) {
+			return elem
+		}
 
-        if let elem = placeholder(for: content) {
-            return elem
-        }
+		if let elem = placeholder(for: content) {
+			return elem
+		}
 
-        return nil
-    }
+		return nil
+	}
 
-    private func textElement(for content: String) -> Element {
-        let adjustedValue = content.replacingOccurrences(of: "\\", with: "")
+	private func textElement(for content: String) -> Element {
+		let adjustedValue = content.replacingOccurrences(of: "\\", with: "")
 
-        return Element.text(adjustedValue)
-    }
+		return Element.text(adjustedValue)
+	}
 
-    private func tabstop(for content: String) -> Element? {
-        let regex = try! NSRegularExpression(pattern: "\\$(\\d+)")
+	private func tabstop(for content: String) -> Element? {
+		let regex = try! NSRegularExpression(pattern: "\\$(\\d+)")
 
-        let matches = regex.matches(inFullString: content)
+		let matches = regex.matches(inFullString: content)
 
-        guard matches.count == 1 else {
-            return nil
-        }
+		guard matches.count == 1 else {
+			return nil
+		}
 
-        guard let tabstopValueRange = matches[0].range(at: 1, in: content) else {
-            return nil
-        }
+		guard let tabstopValueRange = matches[0].range(at: 1, in: content) else {
+			return nil
+		}
 
-        guard let tabstopValue = Int(content[tabstopValueRange]) else {
-            return nil
-        }
+		guard let tabstopValue = Int(content[tabstopValueRange]) else {
+			return nil
+		}
 
-        return Element.tabstop(tabstopValue)
-    }
+		return Element.tabstop(tabstopValue)
+	}
 
-    private func placeholder(for content: String) -> Element? {
-        let regex = try! NSRegularExpression(pattern: #"\$\{(\d+):(.*)\}"#)
+	private func placeholder(for content: String) -> Element? {
+		let regex = try! NSRegularExpression(pattern: #"\$\{(\d+):(.*)\}"#)
 
-        let matches = regex.matches(inFullString: content)
+		let matches = regex.matches(inFullString: content)
 
-        guard matches.count == 1 else {
-            return nil
-        }
+		guard matches.count == 1 else {
+			return nil
+		}
 
-        guard let numberRange = matches[0].range(at: 1, in: content) else {
-            return nil
-        }
+		guard let numberRange = matches[0].range(at: 1, in: content) else {
+			return nil
+		}
 
-        guard let numberValue = Int(content[numberRange]) else {
-            return nil
-        }
+		guard let numberValue = Int(content[numberRange]) else {
+			return nil
+		}
 
-        let innerContentsRange = matches[0].range(at: 2, in: content)
+		let innerContentsRange = matches[0].range(at: 2, in: content)
 
-        let innerContentValue = innerContentsRange.flatMap { String(content[$0]) } ?? ""
-        let adjustedValue = innerContentValue.replacingOccurrences(of: "\\", with: "")
+		let innerContentValue = innerContentsRange.flatMap { String(content[$0]) } ?? ""
+		let adjustedValue = innerContentValue.replacingOccurrences(of: "\\", with: "")
 
-        return Element.placeholder(numberValue, adjustedValue)
-    }
+		return Element.placeholder(numberValue, adjustedValue)
+	}
 }
 
 extension Snippet {
-    public static func parsePlaceholderValue(_ value: String) -> (String, String) {
-        guard let regex = try? NSRegularExpression(pattern: "(\\w+)\\b(.+)") else {
-            return (value, value)
-        }
+	public static func parsePlaceholderValue(_ value: String) -> (String, String) {
+		guard let regex = try? NSRegularExpression(pattern: "(\\w+)\\b(.+)") else {
+			return (value, value)
+		}
 
-        let matches = regex.matches(inFullString: value)
-        let match = matches.first
+		let matches = regex.matches(inFullString: value)
+		let match = matches.first
 
-        guard let contentRange = match?.range(at: 1, in: value) else {
-            return (value, value)
-        }
+		guard let contentRange = match?.range(at: 1, in: value) else {
+			return (value, value)
+		}
 
-        guard let labelRange = match?.range(at: 2, in: value) else {
-            return (value, value)
-        }
+		guard let labelRange = match?.range(at: 2, in: value) else {
+			return (value, value)
+		}
 
-        let content = String(value[contentRange])
-        let label = String(value[labelRange])
+		let content = String(value[contentRange])
+		let label = String(value[labelRange])
 
-        return (label, content)
-    }
+		return (label, content)
+	}
 }

--- a/Sources/LanguageServerProtocol/Additions/TokenRepresentation.swift
+++ b/Sources/LanguageServerProtocol/Additions/TokenRepresentation.swift
@@ -61,7 +61,7 @@ public final class TokenRepresentation {
 	/// - Returns: Ranges affected by the new data (currently unimplemented).
 	public func applyEdits(_ edits: [SemanticTokensEdit]) -> [LSPRange] {
 		// sort high to low
-		let descendingEdits = edits.sorted(by: {a, b in a.start > b.start })
+		let descendingEdits = edits.sorted(by: { a, b in a.start > b.start })
 
 		for edit in descendingEdits {
 			let start = Int(edit.start)
@@ -99,13 +99,13 @@ public final class TokenRepresentation {
 
 			lastLine = line
 
-			let charDelta = Int(data[i+1])
+			let charDelta = Int(data[i + 1])
 			let startingChar = lastStartChar ?? 0
 			let startChar = (lineDelta == 0 ? startingChar : 0) + charDelta
 
 			lastStartChar = startChar
 
-			let length = Int(data[i+2])
+			let length = Int(data[i + 2])
 
 			let start = Position(line: line, character: startChar)
 			if start >= range.end {
@@ -118,7 +118,7 @@ public final class TokenRepresentation {
 			}
 
 			let tokenRange = LSPRange(start: start, end: end)
-			let typeIndex = Int(data[i+3])
+			let typeIndex = Int(data[i + 3])
 
 			if let token = makeToken(range: tokenRange, typeIndex: typeIndex) {
 				tokens.append(token)

--- a/Sources/LanguageServerProtocol/BaseProtocol.swift
+++ b/Sources/LanguageServerProtocol/BaseProtocol.swift
@@ -10,65 +10,65 @@ public typealias DocumentUri = String
 public typealias ProgressToken = TwoTypeOption<Int, String>
 
 public struct CancelParams: Hashable, Codable, Sendable {
-    public var id: TwoTypeOption<Int, String>
+	public var id: TwoTypeOption<Int, String>
 
-    public init(id: Int) {
-        self.id = .optionA(id)
-    }
+	public init(id: Int) {
+		self.id = .optionA(id)
+	}
 
-    public init(id: String) {
-        self.id = .optionB(id)
-    }
+	public init(id: String) {
+		self.id = .optionB(id)
+	}
 }
 
 public struct ProgressParams: Hashable, Codable, Sendable {
-    public var token: ProgressToken
-    public var value: LSPAny?
+	public var token: ProgressToken
+	public var value: LSPAny?
 }
 
 public struct LogTraceParams: Hashable, Codable, Sendable {
-    public var string: String
-    public var verbose: String?
+	public var string: String
+	public var verbose: String?
 }
 
 public enum TraceValue: String, Hashable, Codable, Sendable {
-    case off
-    case messages
-    case verbose
+	case off
+	case messages
+	case verbose
 }
 
 public struct SetTraceParams: Hashable, Codable, Sendable {
-    public var value: TraceValue
+	public var value: TraceValue
 
-    public init(value: TraceValue) {
-        self.value = value
-    }
+	public init(value: TraceValue) {
+		self.value = value
+	}
 }
 
 public struct ValueSet<T: Hashable & Codable>: Hashable, Codable {
-    public var valueSet: [T]
+	public var valueSet: [T]
 
-    public init(valueSet: [T]) {
-        self.valueSet = valueSet
-    }
+	public init(valueSet: [T]) {
+		self.valueSet = valueSet
+	}
 
-    public init(value: T) {
-        self.valueSet = [value]
-    }
+	public init(value: T) {
+		self.valueSet = [value]
+	}
 }
 
 extension ValueSet: ExpressibleByArrayLiteral {
-    public typealias ArrayLiteralElement = T
+	public typealias ArrayLiteralElement = T
 
-    public init(arrayLiteral elements: T...) {
-        self.valueSet = elements
-    }
+	public init(arrayLiteral elements: T...) {
+		self.valueSet = elements
+	}
 }
 
-public extension ValueSet where T: CaseIterable {
-    static var all: ValueSet<T> {
-        return ValueSet(valueSet: Array(T.allCases))
-    }
+extension ValueSet where T: CaseIterable {
+	public static var all: ValueSet<T> {
+		return ValueSet(valueSet: Array(T.allCases))
+	}
 }
 
 extension ValueSet: Sendable where T: Sendable {
@@ -80,8 +80,8 @@ public enum LanguageIdentifier: String, Codable, CaseIterable, Sendable {
 	case bibtex
 	case clojure = "clojure"
 	case coffeescript
-    case c
-    case cpp
+	case c
+	case cpp
 	case csharp
 	case css
 	case diff
@@ -92,7 +92,7 @@ public enum LanguageIdentifier: String, Codable, CaseIterable, Sendable {
 	case fsharp
 	case gitcommit
 	case gitrebase
-    case go
+	case go
 	case groovy
 	case handlebars
 	case html
@@ -100,31 +100,31 @@ public enum LanguageIdentifier: String, Codable, CaseIterable, Sendable {
 	case java
 	case javascript
 	case javascriptreact
-    case json
+	case json
 	case latex
 	case less
 	case lua
 	case makefile
 	case markdown
-    case objc = "objective-c"
-    case objcpp = "objective-cpp"
+	case objc = "objective-c"
+	case objcpp = "objective-cpp"
 	case perl
 	case perl6
-    case php
+	case php
 	case powershell
 	case pug = "jade"
 	case python
 	case r
 	case razor
-    case ruby
-    case rust
+	case ruby
+	case rust
 	case scss
 	case sass
 	case scala
 	case shaderlab
 	case shellscript
 	case sql
-    case swift
+	case swift
 	case typescript
 	case typescriptreact
 	case tex
@@ -135,11 +135,12 @@ public enum LanguageIdentifier: String, Codable, CaseIterable, Sendable {
 }
 
 public struct DocumentFilter: Codable, Hashable, Sendable {
-    public let language: LanguageIdentifier?
-    public let scheme: String?
-    public let pattern: String?
+	public let language: LanguageIdentifier?
+	public let scheme: String?
+	public let pattern: String?
 
-	public init(language: LanguageIdentifier? = nil, scheme: String? = nil, pattern: String? = nil) {
+	public init(language: LanguageIdentifier? = nil, scheme: String? = nil, pattern: String? = nil)
+	{
 		self.language = language
 		self.scheme = scheme
 		self.pattern = pattern
@@ -149,19 +150,19 @@ public struct DocumentFilter: Codable, Hashable, Sendable {
 public typealias DocumentSelector = [DocumentFilter]
 
 public struct TextDocumentIdentifier: Codable, Hashable, Sendable {
-    public var uri: DocumentUri
+	public var uri: DocumentUri
 
-    public init(uri: DocumentUri) {
-        self.uri = uri
-    }
+	public init(uri: DocumentUri) {
+		self.uri = uri
+	}
 
-    public init(path: String) {
-        self.uri = URL(fileURLWithPath: path).absoluteString
-    }
+	public init(path: String) {
+		self.uri = URL(fileURLWithPath: path).absoluteString
+	}
 }
 
 extension TextDocumentIdentifier: CustomStringConvertible {
-    public var description: String {
-        return uri.description
-    }
+	public var description: String {
+		return uri.description
+	}
 }

--- a/Sources/LanguageServerProtocol/BasicStructures.swift
+++ b/Sources/LanguageServerProtocol/BasicStructures.swift
@@ -2,85 +2,85 @@ import Foundation
 import JSONRPC
 
 public struct Position: Codable, Hashable, Sendable {
-    public static let zero = Position(line: 0, character: 0)
+	public static let zero = Position(line: 0, character: 0)
 
-    public let line: Int
-    public let character: Int
+	public let line: Int
+	public let character: Int
 
-    public init(line: Int, character: Int) {
-        self.line = line
-        self.character = character
-    }
+	public init(line: Int, character: Int) {
+		self.line = line
+		self.character = character
+	}
 
-    public init(_ pair: (Int, Int)) {
-        self.line = pair.0
-        self.character = pair.1
-    }
+	public init(_ pair: (Int, Int)) {
+		self.line = pair.0
+		self.character = pair.1
+	}
 }
 
 extension Position: CustomStringConvertible {
-    public var description: String {
-        return "{\(line), \(character)}"
-    }
+	public var description: String {
+		return "{\(line), \(character)}"
+	}
 }
 
 extension Position: Comparable {
-    public static func < (lhs: Position, rhs: Position) -> Bool {
-        if lhs.line == rhs.line {
-            return lhs.character < rhs.character
-        }
+	public static func < (lhs: Position, rhs: Position) -> Bool {
+		if lhs.line == rhs.line {
+			return lhs.character < rhs.character
+		}
 
-        return lhs.line < rhs.line
-    }
+		return lhs.line < rhs.line
+	}
 }
 
 public struct LSPRange: Codable, Hashable, Sendable {
-    public static let zero = LSPRange(start: .zero, end: .zero)
+	public static let zero = LSPRange(start: .zero, end: .zero)
 
-    public let start: Position
-    public let end: Position
+	public let start: Position
+	public let end: Position
 
-    public init(start: Position, end: Position) {
-        self.start = start
-        self.end = end
-    }
+	public init(start: Position, end: Position) {
+		self.start = start
+		self.end = end
+	}
 
-    public init(startPair: (Int, Int), endPair: (Int, Int)) {
-        self.start = Position(startPair)
-        self.end = Position(endPair)
-    }
+	public init(startPair: (Int, Int), endPair: (Int, Int)) {
+		self.start = Position(startPair)
+		self.end = Position(endPair)
+	}
 
-    public func contains(_ position: Position) -> Bool {
-        return position > start && position < end
-    }
+	public func contains(_ position: Position) -> Bool {
+		return position > start && position < end
+	}
 
-    public func intersects(_ other: LSPRange) -> Bool {
-        return contains(other.start) || contains(other.end)
-    }
+	public func intersects(_ other: LSPRange) -> Bool {
+		return contains(other.start) || contains(other.end)
+	}
 
-    public var isEmpty: Bool {
-        return start == end
-    }
+	public var isEmpty: Bool {
+		return start == end
+	}
 }
 
 extension LSPRange: CustomStringConvertible {
-    public var description: String {
-        return "(\(start), \(end))"
-    }
+	public var description: String {
+		return "(\(start), \(end))"
+	}
 }
 
 public struct TextDocumentItem: Codable, Hashable, Sendable {
-    public let uri: DocumentUri
-    public let languageId: String
-    public let version: Int
-    public let text: String
+	public let uri: DocumentUri
+	public let languageId: String
+	public let version: Int
+	public let text: String
 
-    public init(uri: DocumentUri, languageId: LanguageIdentifier, version: Int, text: String) {
-        self.uri = uri
+	public init(uri: DocumentUri, languageId: LanguageIdentifier, version: Int, text: String) {
+		self.uri = uri
 		self.languageId = languageId.rawValue
-        self.version = version
-        self.text = text
-    }
+		self.version = version
+		self.text = text
+	}
 
 	public init(uri: DocumentUri, languageId: String, version: Int, text: String) {
 		self.uri = uri
@@ -91,26 +91,26 @@ public struct TextDocumentItem: Codable, Hashable, Sendable {
 }
 
 public struct VersionedTextDocumentIdentifier: Codable, Hashable, Sendable {
-    public let uri: DocumentUri
-    public let version: Int?
+	public let uri: DocumentUri
+	public let version: Int?
 
-    public init(uri: DocumentUri, version: Int?) {
-        self.uri = uri
-        self.version = version
-    }
+	public init(uri: DocumentUri, version: Int?) {
+		self.uri = uri
+		self.version = version
+	}
 }
 
 extension VersionedTextDocumentIdentifier: CustomStringConvertible {
-    public var description: String {
-        let vString = version.map { String($0) } ?? "<unknown>"
+	public var description: String {
+		let vString = version.map { String($0) } ?? "<unknown>"
 
-        return "\(uri.description): Version \(vString)"
-    }
+		return "\(uri.description): Version \(vString)"
+	}
 }
 
 public struct Location: Codable, Hashable, Sendable {
-    public let uri: DocumentUri
-    public let range: LSPRange
+	public let uri: DocumentUri
+	public let range: LSPRange
 
 	public init(uri: DocumentUri, range: LSPRange) {
 		self.uri = uri
@@ -119,94 +119,97 @@ public struct Location: Codable, Hashable, Sendable {
 }
 
 public struct Command: Codable, Hashable, Sendable {
-    public let title: String
-    public let command: String
-    public let arguments: [LSPAny]?
+	public let title: String
+	public let command: String
+	public let arguments: [LSPAny]?
 }
 
 public enum SymbolKind: Int, CaseIterable, Hashable, Codable, Sendable {
-    case file = 1
-    case module = 2
-    case namespace = 3
-    case package = 4
-    case `class` = 5
-    case method = 6
-    case property = 7
-    case field = 8
-    case constructor = 9
-    case `enum` = 10
-    case interface = 11
-    case function = 12
-    case variable = 13
-    case constant = 14
-    case string = 15
-    case number = 16
-    case boolean = 17
-    case array = 18
-    case object = 19
-    case key = 20
-    case null = 21
-    case enumMember = 22
-    case `struct` = 23
-    case event = 24
-    case `operator` = 25
-    case typeParameter = 26
+	case file = 1
+	case module = 2
+	case namespace = 3
+	case package = 4
+	case `class` = 5
+	case method = 6
+	case property = 7
+	case field = 8
+	case constructor = 9
+	case `enum` = 10
+	case interface = 11
+	case function = 12
+	case variable = 13
+	case constant = 14
+	case string = 15
+	case number = 16
+	case boolean = 17
+	case array = 18
+	case object = 19
+	case key = 20
+	case null = 21
+	case enumMember = 22
+	case `struct` = 23
+	case event = 24
+	case `operator` = 25
+	case typeParameter = 26
 }
 
 public enum MarkupKind: String, Codable, Hashable, Sendable {
-    case plaintext
-    case markdown
+	case plaintext
+	case markdown
 }
 
 public struct TextDocumentPositionParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
-    public let position: Position
+	public let textDocument: TextDocumentIdentifier
+	public let position: Position
 
-    public init(textDocument: TextDocumentIdentifier, position: Position) {
-        self.textDocument = textDocument
-        self.position = position
-    }
+	public init(textDocument: TextDocumentIdentifier, position: Position) {
+		self.textDocument = textDocument
+		self.position = position
+	}
 
-    public init(uri: DocumentUri, position: Position) {
-        let textDocId = TextDocumentIdentifier(uri: uri)
+	public init(uri: DocumentUri, position: Position) {
+		let textDocId = TextDocumentIdentifier(uri: uri)
 
-        self.init(textDocument: textDocId, position: position)
-    }
+		self.init(textDocument: textDocId, position: position)
+	}
 }
 
 public struct LanguageStringPair: Codable, Hashable, Sendable {
-    public let language: LanguageIdentifier
-    public let value: String
+	public let language: LanguageIdentifier
+	public let value: String
 }
 
 public typealias MarkedString = TwoTypeOption<String, LanguageStringPair>
 
-public extension MarkedString {
-    var value: String {
-        switch self {
-        case .optionA(let string):
-            return string
-        case .optionB(let pair):
-            return pair.value
-        }
-    }
+extension MarkedString {
+	public var value: String {
+		switch self {
+		case .optionA(let string):
+			return string
+		case .optionB(let pair):
+			return pair.value
+		}
+	}
 }
 
 public struct MarkupContent: Codable, Hashable, Sendable {
-    public let kind: MarkupKind
-    public let value: String
+	public let kind: MarkupKind
+	public let value: String
 }
 
 public struct LocationLink: Codable, Hashable, Sendable {
-	public init(originSelectionRange: LSPRange? = nil, targetUri: String, targetRange: LSPRange, targetSelectionRange: LSPRange) {
+	public init(
+		originSelectionRange: LSPRange? = nil, targetUri: String, targetRange: LSPRange,
+		targetSelectionRange: LSPRange
+	) {
 		self.originSelectionRange = originSelectionRange
 		self.targetUri = targetUri
 		self.targetRange = targetRange
 		self.targetSelectionRange = targetSelectionRange
 	}
 
-    public let originSelectionRange: LSPRange?
-    public let targetUri: String
-    public let targetRange: LSPRange
-    public let targetSelectionRange: LSPRange
+	public let originSelectionRange: LSPRange?
+	public let targetUri: String
+	public let targetRange: LSPRange
+	public let targetSelectionRange: LSPRange
 }

--- a/Sources/LanguageServerProtocol/Client.swift
+++ b/Sources/LanguageServerProtocol/Client.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public struct Registration: Codable, Hashable, Sendable {
-    public var id: String
-    public var method: String
-    public var registerOptions: LSPAny?
+	public var id: String
+	public var method: String
+	public var registerOptions: LSPAny?
 
 	public init(id: String, method: String, registerOptions: LSPAny? = nil) {
 		self.id = id
@@ -13,60 +13,60 @@ public struct Registration: Codable, Hashable, Sendable {
 }
 
 extension Registration {
-    var registerOptionsData: Data? {
-        return try? JSONEncoder().encode(registerOptions)
-    }
+	var registerOptionsData: Data? {
+		return try? JSONEncoder().encode(registerOptions)
+	}
 
-    func reintrepretOptions<T: Decodable>(_ type: T.Type) throws -> T {
-        let data = try JSONEncoder().encode(registerOptions)
+	func reintrepretOptions<T: Decodable>(_ type: T.Type) throws -> T {
+		let data = try JSONEncoder().encode(registerOptions)
 
-        return try JSONDecoder().decode(type.self, from: data)
-    }
+		return try JSONDecoder().decode(type.self, from: data)
+	}
 
-    func decodeServerRegistration() throws -> ServerRegistration {
-        guard let regMethod = ServerRegistration.Method(rawValue: method) else {
-            throw ServerError.unhandledRegisterationMethod(method)
-        }
+	func decodeServerRegistration() throws -> ServerRegistration {
+		guard let regMethod = ServerRegistration.Method(rawValue: method) else {
+			throw ServerError.unhandledRegisterationMethod(method)
+		}
 
-        switch regMethod {
-        case .workspaceDidChangeWatchedFiles:
-            let options = try reintrepretOptions(DidChangeWatchedFilesRegistrationOptions.self)
+		switch regMethod {
+		case .workspaceDidChangeWatchedFiles:
+			let options = try reintrepretOptions(DidChangeWatchedFilesRegistrationOptions.self)
 
-            return .workspaceDidChangeWatchedFiles(options)
-        case .workspaceDidChangeConfiguration:
-            return .workspaceDidChangeConfiguration
-        case .workspaceDidChangeWorkspaceFolders:
-            return .workspaceDidChangeWorkspaceFolders
-        case .textDocumentSemanticTokens:
-            let options = try reintrepretOptions(SemanticTokensRegistrationOptions.self)
+			return .workspaceDidChangeWatchedFiles(options)
+		case .workspaceDidChangeConfiguration:
+			return .workspaceDidChangeConfiguration
+		case .workspaceDidChangeWorkspaceFolders:
+			return .workspaceDidChangeWorkspaceFolders
+		case .textDocumentSemanticTokens:
+			let options = try reintrepretOptions(SemanticTokensRegistrationOptions.self)
 
-            return .textDocumentSemanticTokens(options)
+			return .textDocumentSemanticTokens(options)
 
-        }
-    }
+		}
+	}
 
-    public var serverRegistration: ServerRegistration? {
-        return try? decodeServerRegistration()
-    }
+	public var serverRegistration: ServerRegistration? {
+		return try? decodeServerRegistration()
+	}
 }
 
 public struct RegistrationParams: Codable, Hashable, Sendable {
-    public var registrations: [Registration]
+	public var registrations: [Registration]
 
 	public init(registrations: [Registration]) {
 		self.registrations = registrations
 	}
 
-    public var serverRegistrations: [ServerRegistration] {
-        return registrations.compactMap({ $0.serverRegistration })
-    }
+	public var serverRegistrations: [ServerRegistration] {
+		return registrations.compactMap({ $0.serverRegistration })
+	}
 }
 
 public struct Unregistration: Codable, Hashable, Sendable {
-    public var id: String
-    public var method: String
+	public var id: String
+	public var method: String
 }
 
 public struct UnregistrationParams: Codable, Hashable, Sendable {
-    public var unregistrations: [Unregistration]
+	public var unregistrations: [Unregistration]
 }

--- a/Sources/LanguageServerProtocol/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ClientCapabilities.swift
@@ -1,46 +1,49 @@
 import Foundation
 
 public struct DynamicRegistrationClientCapabilities: Codable, Hashable, Sendable {
-    public var dynamicRegistration: Bool?
+	public var dynamicRegistration: Bool?
 
-    public init(dynamicRegistration: Bool) {
-        self.dynamicRegistration = dynamicRegistration
-    }
+	public init(dynamicRegistration: Bool) {
+		self.dynamicRegistration = dynamicRegistration
+	}
 }
 
 public struct DynamicRegistrationLinkSupportClientCapabilities: Codable, Hashable, Sendable {
-    public var dynamicRegistration: Bool?
-    public var linkSupport: Bool?
+	public var dynamicRegistration: Bool?
+	public var linkSupport: Bool?
 
-    public init(dynamicRegistration: Bool, linkSupport: Bool) {
-        self.dynamicRegistration = dynamicRegistration
-        self.linkSupport = linkSupport
-    }
+	public init(dynamicRegistration: Bool, linkSupport: Bool) {
+		self.dynamicRegistration = dynamicRegistration
+		self.linkSupport = linkSupport
+	}
 }
 
 public enum ResourceOperationKind: String, Codable, Hashable, Sendable {
-    case create
-    case rename
-    case delete
+	case create
+	case rename
+	case delete
 }
 
 public enum FailureHandlingKind: String, Codable, Hashable, Sendable {
-    case abort
-    case transactional
-    case textOnlyTransactional
-    case undo
+	case abort
+	case transactional
+	case textOnlyTransactional
+	case undo
 }
 
 public struct WorkspaceClientCapabilityEdit: Codable, Hashable, Sendable {
-    public let documentChanges: Bool?
-    public let resourceOperations: [ResourceOperationKind]
-    public let failureHandling: FailureHandlingKind?
+	public let documentChanges: Bool?
+	public let resourceOperations: [ResourceOperationKind]
+	public let failureHandling: FailureHandlingKind?
 
-    public init(documentChanges: Bool?, resourceOperations: [ResourceOperationKind], failureHandling: FailureHandlingKind?) {
-        self.documentChanges = documentChanges
-        self.resourceOperations = resourceOperations
-        self.failureHandling = failureHandling
-    }
+	public init(
+		documentChanges: Bool?, resourceOperations: [ResourceOperationKind],
+		failureHandling: FailureHandlingKind?
+	) {
+		self.documentChanges = documentChanges
+		self.resourceOperations = resourceOperations
+		self.failureHandling = failureHandling
+	}
 }
 
 public typealias DidChangeConfigurationClientCapabilities = GenericDynamicRegistration
@@ -48,242 +51,257 @@ public typealias DidChangeConfigurationClientCapabilities = GenericDynamicRegist
 public typealias DidChangeWatchedFilesClientCapabilities = GenericDynamicRegistration
 
 public struct ShowDocumentClientCapabilities: Hashable, Codable, Sendable {
-    public var support: Bool
+	public var support: Bool
 }
 
 public struct ShowMessageRequestClientCapabilities: Hashable, Codable, Sendable {
-    public struct MessageActionItemCapabilities: Hashable, Codable, Sendable {
-        public var additionalPropertiesSupport: Bool
-    }
+	public struct MessageActionItemCapabilities: Hashable, Codable, Sendable {
+		public var additionalPropertiesSupport: Bool
+	}
 
-    public var messageActionItem: MessageActionItemCapabilities
+	public var messageActionItem: MessageActionItemCapabilities
 
-    init(messageActionItem: MessageActionItemCapabilities) {
-        self.messageActionItem = messageActionItem
-    }
+	init(messageActionItem: MessageActionItemCapabilities) {
+		self.messageActionItem = messageActionItem
+	}
 }
 
 public struct WindowClientCapabilities: Hashable, Codable, Sendable {
-    public var workDoneProgress: Bool
-    public var showMessage: ShowMessageRequestClientCapabilities
-    public var showDocument: ShowDocumentClientCapabilities
+	public var workDoneProgress: Bool
+	public var showMessage: ShowMessageRequestClientCapabilities
+	public var showDocument: ShowDocumentClientCapabilities
 
-    public init(workDoneProgress: Bool, showMessage: ShowMessageRequestClientCapabilities, showDocument: ShowDocumentClientCapabilities) {
-        self.workDoneProgress = workDoneProgress
-        self.showMessage = showMessage
-        self.showDocument = showDocument
-    }
+	public init(
+		workDoneProgress: Bool, showMessage: ShowMessageRequestClientCapabilities,
+		showDocument: ShowDocumentClientCapabilities
+	) {
+		self.workDoneProgress = workDoneProgress
+		self.showMessage = showMessage
+		self.showDocument = showDocument
+	}
 }
 
 public struct RegularExpressionsClientCapabilities: Hashable, Codable, Sendable {
-    public var engine: String
-    public var version: String?
+	public var engine: String
+	public var version: String?
 
-    public init(engine: String, version: String? = nil) {
-        self.engine = engine
-        self.version = version
-    }
+	public init(engine: String, version: String? = nil) {
+		self.engine = engine
+		self.version = version
+	}
 }
 
 public struct MarkdownClientCapabilities: Hashable, Codable, Sendable {
-    public var parser: String
-    public var version: String?
-    public var allowedTags: [String]?
+	public var parser: String
+	public var version: String?
+	public var allowedTags: [String]?
 
-    public init(parser: String, version: String? = nil, allowedTags: [String]? = nil) {
-        self.parser = parser
-        self.version = version
-        self.allowedTags = allowedTags
-    }
+	public init(parser: String, version: String? = nil, allowedTags: [String]? = nil) {
+		self.parser = parser
+		self.version = version
+		self.allowedTags = allowedTags
+	}
 }
 
 public struct GeneralClientCapabilities: Hashable, Codable, Sendable {
-    public var regularExpressions: RegularExpressionsClientCapabilities?
-    public var markdown: MarkdownClientCapabilities?
+	public var regularExpressions: RegularExpressionsClientCapabilities?
+	public var markdown: MarkdownClientCapabilities?
 
-    public init(regularExpressions: RegularExpressionsClientCapabilities?, markdown: MarkdownClientCapabilities?) {
-        self.regularExpressions = regularExpressions
-        self.markdown = markdown
-    }
+	public init(
+		regularExpressions: RegularExpressionsClientCapabilities?,
+		markdown: MarkdownClientCapabilities?
+	) {
+		self.regularExpressions = regularExpressions
+		self.markdown = markdown
+	}
 }
 
 public struct TextDocumentSyncClientCapabilities: Codable, Hashable, Sendable {
-    public let dynamicRegistration: Bool?
-    public let willSave: Bool?
-    public let willSaveWaitUntil: Bool?
-    public let didSave: Bool?
+	public let dynamicRegistration: Bool?
+	public let willSave: Bool?
+	public let willSaveWaitUntil: Bool?
+	public let didSave: Bool?
 
-    public init(dynamicRegistration: Bool, willSave: Bool, willSaveWaitUntil: Bool, didSave: Bool) {
-        self.dynamicRegistration = dynamicRegistration
-        self.willSave = willSave
-        self.willSaveWaitUntil = willSaveWaitUntil
-        self.didSave = didSave
-    }
+	public init(dynamicRegistration: Bool, willSave: Bool, willSaveWaitUntil: Bool, didSave: Bool) {
+		self.dynamicRegistration = dynamicRegistration
+		self.willSave = willSave
+		self.willSaveWaitUntil = willSaveWaitUntil
+		self.didSave = didSave
+	}
 }
 
 public struct TextDocumentClientCapabilities: Codable, Hashable, Sendable {
-    public var synchronization: TextDocumentSyncClientCapabilities?
-    public var completion: CompletionClientCapabilities?
-    public var hover: HoverClientCapabilities?
-    public var signatureHelp: SignatureHelpClientCapabilities?
-    public var declaration: DeclarationClientCapabilities?
-    public var definition: DefinitionClientCapabilities?
-    public var typeDefinition: TypeDefinitionClientCapabilities?
-    public var implementation: ImplementationClientCapabilities?
-    public var references: ReferenceClientCapabilities?
-    public var documentHighlight: DocumentHighlightClientCapabilities?
-    public var documentSymbol: DocumentSymbolClientCapabilities?
-    public var codeAction: CodeActionClientCapabilities?
-    public var codeLens: CodeLensClientCapabilities?
-    public var documentLink: DocumentLinkClientCapabilities?
-    public var colorProvider: DocumentColorClientCapabilities?
-    public var formatting: DocumentFormattingClientCapabilities?
-    public var rangeFormatting: DocumentRangeFormattingClientCapabilities?
-    public var onTypeFormatting: DocumentOnTypeFormattingClientCapabilities?
-    public var rename: RenameClientCapabilities?
-    public var publishDiagnostics: PublishDiagnosticsClientCapabilities?
-    public var foldingRange: FoldingRangeClientCapabilities?
-    public var selectionRange: SelectionRangeClientCapabilities?
-    public var linkedEditingRange: LinkedEditingRangeClientCapabilities?
-    public var callHierarchy: CallHierarchyClientCapabilities?
-    public var semanticTokens: SemanticTokensClientCapabilities?
-    public var moniker: MonikerClientCapabilities?
+	public var synchronization: TextDocumentSyncClientCapabilities?
+	public var completion: CompletionClientCapabilities?
+	public var hover: HoverClientCapabilities?
+	public var signatureHelp: SignatureHelpClientCapabilities?
+	public var declaration: DeclarationClientCapabilities?
+	public var definition: DefinitionClientCapabilities?
+	public var typeDefinition: TypeDefinitionClientCapabilities?
+	public var implementation: ImplementationClientCapabilities?
+	public var references: ReferenceClientCapabilities?
+	public var documentHighlight: DocumentHighlightClientCapabilities?
+	public var documentSymbol: DocumentSymbolClientCapabilities?
+	public var codeAction: CodeActionClientCapabilities?
+	public var codeLens: CodeLensClientCapabilities?
+	public var documentLink: DocumentLinkClientCapabilities?
+	public var colorProvider: DocumentColorClientCapabilities?
+	public var formatting: DocumentFormattingClientCapabilities?
+	public var rangeFormatting: DocumentRangeFormattingClientCapabilities?
+	public var onTypeFormatting: DocumentOnTypeFormattingClientCapabilities?
+	public var rename: RenameClientCapabilities?
+	public var publishDiagnostics: PublishDiagnosticsClientCapabilities?
+	public var foldingRange: FoldingRangeClientCapabilities?
+	public var selectionRange: SelectionRangeClientCapabilities?
+	public var linkedEditingRange: LinkedEditingRangeClientCapabilities?
+	public var callHierarchy: CallHierarchyClientCapabilities?
+	public var semanticTokens: SemanticTokensClientCapabilities?
+	public var moniker: MonikerClientCapabilities?
 	public var diagnostic: DiagnosticClientCapabilities?
 
-    public init(synchronization: TextDocumentSyncClientCapabilities? = nil,
-                completion: CompletionClientCapabilities? = nil,
-                hover: HoverClientCapabilities? = nil,
-                signatureHelp: SignatureHelpClientCapabilities? = nil,
-                declaration: DeclarationClientCapabilities? = nil,
-                definition: DefinitionClientCapabilities? = nil,
-                typeDefinition: TypeDefinitionClientCapabilities? = nil,
-                implementation: ImplementationClientCapabilities? = nil,
-                references: ReferenceClientCapabilities? = nil,
-                documentHighlight: DocumentHighlightClientCapabilities? = nil,
-                documentSymbol: DocumentSymbolClientCapabilities? = nil,
-                codeAction: CodeActionClientCapabilities? = nil,
-                codeLens: CodeLensClientCapabilities? = nil,
-                documentLink: DocumentLinkClientCapabilities? = nil,
-                colorProvider: DocumentColorClientCapabilities? = nil,
-                formatting: DocumentFormattingClientCapabilities? = nil,
-                rangeFormatting: DocumentRangeFormattingClientCapabilities? = nil,
-                onTypeFormatting: DocumentOnTypeFormattingClientCapabilities? = nil,
-                rename: RenameClientCapabilities? = nil,
-                publishDiagnostics: PublishDiagnosticsClientCapabilities? = nil,
-                foldingRange: FoldingRangeClientCapabilities? = nil,
-                selectionRange: SelectionRangeClientCapabilities? = nil,
-                linkedEditingRange: LinkedEditingRangeClientCapabilities? = nil,
-                callHierarchy: CallHierarchyClientCapabilities? = nil,
-                semanticTokens: SemanticTokensClientCapabilities? = nil,
-                moniker: MonikerClientCapabilities? = nil,
-				diagnostic: DiagnosticClientCapabilities? = nil) {
-        self.synchronization = synchronization
-        self.completion = completion
-        self.hover = hover
-        self.signatureHelp = signatureHelp
-        self.declaration = declaration
-        self.definition = definition
-        self.typeDefinition = typeDefinition
-        self.implementation = implementation
-        self.references = references
-        self.documentHighlight = documentHighlight
-        self.documentSymbol = documentSymbol
-        self.codeAction = codeAction
-        self.codeLens = codeLens
-        self.documentLink = documentLink
-        self.colorProvider = colorProvider
-        self.formatting = formatting
-        self.rangeFormatting = rangeFormatting
-        self.onTypeFormatting = onTypeFormatting
-        self.rename = rename
-        self.publishDiagnostics = publishDiagnostics
-        self.foldingRange = foldingRange
-        self.selectionRange = selectionRange
-        self.linkedEditingRange = linkedEditingRange
-        self.callHierarchy = callHierarchy
-        self.semanticTokens = semanticTokens
-        self.moniker = moniker
+	public init(
+		synchronization: TextDocumentSyncClientCapabilities? = nil,
+		completion: CompletionClientCapabilities? = nil,
+		hover: HoverClientCapabilities? = nil,
+		signatureHelp: SignatureHelpClientCapabilities? = nil,
+		declaration: DeclarationClientCapabilities? = nil,
+		definition: DefinitionClientCapabilities? = nil,
+		typeDefinition: TypeDefinitionClientCapabilities? = nil,
+		implementation: ImplementationClientCapabilities? = nil,
+		references: ReferenceClientCapabilities? = nil,
+		documentHighlight: DocumentHighlightClientCapabilities? = nil,
+		documentSymbol: DocumentSymbolClientCapabilities? = nil,
+		codeAction: CodeActionClientCapabilities? = nil,
+		codeLens: CodeLensClientCapabilities? = nil,
+		documentLink: DocumentLinkClientCapabilities? = nil,
+		colorProvider: DocumentColorClientCapabilities? = nil,
+		formatting: DocumentFormattingClientCapabilities? = nil,
+		rangeFormatting: DocumentRangeFormattingClientCapabilities? = nil,
+		onTypeFormatting: DocumentOnTypeFormattingClientCapabilities? = nil,
+		rename: RenameClientCapabilities? = nil,
+		publishDiagnostics: PublishDiagnosticsClientCapabilities? = nil,
+		foldingRange: FoldingRangeClientCapabilities? = nil,
+		selectionRange: SelectionRangeClientCapabilities? = nil,
+		linkedEditingRange: LinkedEditingRangeClientCapabilities? = nil,
+		callHierarchy: CallHierarchyClientCapabilities? = nil,
+		semanticTokens: SemanticTokensClientCapabilities? = nil,
+		moniker: MonikerClientCapabilities? = nil,
+		diagnostic: DiagnosticClientCapabilities? = nil
+	) {
+		self.synchronization = synchronization
+		self.completion = completion
+		self.hover = hover
+		self.signatureHelp = signatureHelp
+		self.declaration = declaration
+		self.definition = definition
+		self.typeDefinition = typeDefinition
+		self.implementation = implementation
+		self.references = references
+		self.documentHighlight = documentHighlight
+		self.documentSymbol = documentSymbol
+		self.codeAction = codeAction
+		self.codeLens = codeLens
+		self.documentLink = documentLink
+		self.colorProvider = colorProvider
+		self.formatting = formatting
+		self.rangeFormatting = rangeFormatting
+		self.onTypeFormatting = onTypeFormatting
+		self.rename = rename
+		self.publishDiagnostics = publishDiagnostics
+		self.foldingRange = foldingRange
+		self.selectionRange = selectionRange
+		self.linkedEditingRange = linkedEditingRange
+		self.callHierarchy = callHierarchy
+		self.semanticTokens = semanticTokens
+		self.moniker = moniker
 		self.diagnostic = diagnostic
-    }
+	}
 }
 
 public struct ClientCapabilities: Codable, Hashable, Sendable {
-    public struct Workspace: Codable, Hashable, Sendable {
-        public struct FileOperations: Codable, Hashable, Sendable {
-            public var dynamicRegistration: Bool?
-            public var didCreate: Bool?
-            public var willCreate: Bool?
-            public var didRename: Bool?
-            public var willRename: Bool?
-            public var didDelete: Bool?
-            public var willDelete: Bool?
+	public struct Workspace: Codable, Hashable, Sendable {
+		public struct FileOperations: Codable, Hashable, Sendable {
+			public var dynamicRegistration: Bool?
+			public var didCreate: Bool?
+			public var willCreate: Bool?
+			public var didRename: Bool?
+			public var willRename: Bool?
+			public var didDelete: Bool?
+			public var willDelete: Bool?
 
-            public init(dynamicRegistration: Bool? = nil,
-                        didCreate: Bool? = nil,
-                        willCreate: Bool? = nil,
-                        didRename: Bool? = nil,
-                        willRename: Bool? = nil,
-                        didDelete: Bool? = nil,
-                        willDelete: Bool? = nil) {
-                self.dynamicRegistration = dynamicRegistration
-                self.didCreate = didCreate
-                self.willCreate = willCreate
-                self.didRename = didRename
-                self.willRename = willRename
-                self.didDelete = didDelete
-                self.willDelete = willDelete
-            }
-        }
+			public init(
+				dynamicRegistration: Bool? = nil,
+				didCreate: Bool? = nil,
+				willCreate: Bool? = nil,
+				didRename: Bool? = nil,
+				willRename: Bool? = nil,
+				didDelete: Bool? = nil,
+				willDelete: Bool? = nil
+			) {
+				self.dynamicRegistration = dynamicRegistration
+				self.didCreate = didCreate
+				self.willCreate = willCreate
+				self.didRename = didRename
+				self.willRename = willRename
+				self.didDelete = didDelete
+				self.willDelete = willDelete
+			}
+		}
 
-        public let applyEdit: Bool?
-        public let workspaceEdit: WorkspaceClientCapabilityEdit?
-        public let didChangeConfiguration: DidChangeConfigurationClientCapabilities?
-        public let didChangeWatchedFiles: GenericDynamicRegistration?
-        public let symbol: WorkspaceSymbolClientCapabilities?
-        public let executeCommand: GenericDynamicRegistration?
-        public let workspaceFolders: Bool?
-        public let configuration: Bool?
-        public let semanticTokens: SemanticTokensWorkspaceClientCapabilities?
-        public let codeLens: CodeLensWorkspaceClientCapabilities?
-        public let fileOperations: FileOperations?
+		public let applyEdit: Bool?
+		public let workspaceEdit: WorkspaceClientCapabilityEdit?
+		public let didChangeConfiguration: DidChangeConfigurationClientCapabilities?
+		public let didChangeWatchedFiles: GenericDynamicRegistration?
+		public let symbol: WorkspaceSymbolClientCapabilities?
+		public let executeCommand: GenericDynamicRegistration?
+		public let workspaceFolders: Bool?
+		public let configuration: Bool?
+		public let semanticTokens: SemanticTokensWorkspaceClientCapabilities?
+		public let codeLens: CodeLensWorkspaceClientCapabilities?
+		public let fileOperations: FileOperations?
 
-        public init(applyEdit: Bool,
-                    workspaceEdit: WorkspaceClientCapabilityEdit?,
-                    didChangeConfiguration: DidChangeConfigurationClientCapabilities?,
-                    didChangeWatchedFiles: GenericDynamicRegistration?,
-                    symbol: WorkspaceSymbolClientCapabilities?,
-                    executeCommand: GenericDynamicRegistration?,
-                    workspaceFolders: Bool?,
-                    configuration: Bool?,
-                    semanticTokens: SemanticTokensWorkspaceClientCapabilities?,
-                    codeLens: CodeLensWorkspaceClientCapabilities? = nil,
-                    fileOperations: FileOperations? = nil) {
-            self.applyEdit = applyEdit
-            self.workspaceEdit = workspaceEdit
-            self.didChangeConfiguration = didChangeConfiguration
-            self.didChangeWatchedFiles = didChangeWatchedFiles
-            self.symbol = symbol
-            self.executeCommand = executeCommand
-            self.workspaceFolders = workspaceFolders
-            self.configuration = configuration
-            self.semanticTokens = semanticTokens
-            self.codeLens = codeLens
-            self.fileOperations = fileOperations
-        }
-    }
+		public init(
+			applyEdit: Bool,
+			workspaceEdit: WorkspaceClientCapabilityEdit?,
+			didChangeConfiguration: DidChangeConfigurationClientCapabilities?,
+			didChangeWatchedFiles: GenericDynamicRegistration?,
+			symbol: WorkspaceSymbolClientCapabilities?,
+			executeCommand: GenericDynamicRegistration?,
+			workspaceFolders: Bool?,
+			configuration: Bool?,
+			semanticTokens: SemanticTokensWorkspaceClientCapabilities?,
+			codeLens: CodeLensWorkspaceClientCapabilities? = nil,
+			fileOperations: FileOperations? = nil
+		) {
+			self.applyEdit = applyEdit
+			self.workspaceEdit = workspaceEdit
+			self.didChangeConfiguration = didChangeConfiguration
+			self.didChangeWatchedFiles = didChangeWatchedFiles
+			self.symbol = symbol
+			self.executeCommand = executeCommand
+			self.workspaceFolders = workspaceFolders
+			self.configuration = configuration
+			self.semanticTokens = semanticTokens
+			self.codeLens = codeLens
+			self.fileOperations = fileOperations
+		}
+	}
 
+	public let workspace: Workspace?
+	public let textDocument: TextDocumentClientCapabilities?
+	public var window: WindowClientCapabilities?
+	public var general: GeneralClientCapabilities?
+	public let experimental: LSPAny?
 
-    public let workspace: Workspace?
-    public let textDocument: TextDocumentClientCapabilities?
-    public var window: WindowClientCapabilities?
-    public var general: GeneralClientCapabilities?
-    public let experimental: LSPAny?
-
-    public init(workspace: Workspace?, textDocument: TextDocumentClientCapabilities?, window: WindowClientCapabilities?, general: GeneralClientCapabilities?, experimental: LSPAny?) {
-        self.workspace = workspace
-        self.textDocument = textDocument
-        self.window = window
-        self.general = general
-        self.experimental = experimental
-    }
+	public init(
+		workspace: Workspace?, textDocument: TextDocumentClientCapabilities?,
+		window: WindowClientCapabilities?, general: GeneralClientCapabilities?,
+		experimental: LSPAny?
+	) {
+		self.workspace = workspace
+		self.textDocument = textDocument
+		self.window = window
+		self.general = general
+		self.experimental = experimental
+	}
 }

--- a/Sources/LanguageServerProtocol/General.swift
+++ b/Sources/LanguageServerProtocol/General.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public enum Tracing: String, Codable, Hashable, Sendable {
-    case off
-    case messages
-    case verbose
+	case off
+	case messages
+	case verbose
 }
 
 public struct InitializeParams: Codable, Hashable, Sendable {
@@ -17,38 +17,40 @@ public struct InitializeParams: Codable, Hashable, Sendable {
 		}
 	}
 
-    public let processId: Int?
+	public let processId: Int?
 	public let clientInfo: ClientInfo?
 	public let locale: String?
-    public let rootPath: String?
-    public let rootUri: DocumentUri?
-    public let initializationOptions: LSPAny?
-    public let capabilities: ClientCapabilities
-    public let trace: Tracing?
-    public let workspaceFolders: [WorkspaceFolder]?
+	public let rootPath: String?
+	public let rootUri: DocumentUri?
+	public let initializationOptions: LSPAny?
+	public let capabilities: ClientCapabilities
+	public let trace: Tracing?
+	public let workspaceFolders: [WorkspaceFolder]?
 
-    public init(processId: Int,
-				clientInfo: ClientInfo? = nil,
-				locale: String?,
-				rootPath: String?,
-				rootUri: DocumentUri?,
-				initializationOptions: LSPAny?,
-				capabilities: ClientCapabilities,
-				trace: Tracing?,
-				workspaceFolders: [WorkspaceFolder]?) {
-        self.processId = processId
+	public init(
+		processId: Int,
+		clientInfo: ClientInfo? = nil,
+		locale: String?,
+		rootPath: String?,
+		rootUri: DocumentUri?,
+		initializationOptions: LSPAny?,
+		capabilities: ClientCapabilities,
+		trace: Tracing?,
+		workspaceFolders: [WorkspaceFolder]?
+	) {
+		self.processId = processId
 		self.clientInfo = clientInfo
 		self.locale = locale
-        self.rootPath = rootPath
-        self.rootUri = rootUri
-        self.initializationOptions = initializationOptions
-        self.capabilities = capabilities
-        self.trace = trace
-        self.workspaceFolders = workspaceFolders
-    }
+		self.rootPath = rootPath
+		self.rootUri = rootUri
+		self.initializationOptions = initializationOptions
+		self.capabilities = capabilities
+		self.trace = trace
+		self.workspaceFolders = workspaceFolders
+	}
 }
 
-public struct ServerInfo : Codable, Hashable, Sendable {
+public struct ServerInfo: Codable, Hashable, Sendable {
 	/**
 	 * The name of the server as defined by the server.
 	 */
@@ -65,8 +67,8 @@ public struct ServerInfo : Codable, Hashable, Sendable {
 	}
 }
 
-public struct InitializationResponse : Codable, Hashable, Sendable {
-    public let capabilities: ServerCapabilities
+public struct InitializationResponse: Codable, Hashable, Sendable {
+	public let capabilities: ServerCapabilities
 	public let serverInfo: ServerInfo?
 
 	public init(capabilities: ServerCapabilities, serverInfo: ServerInfo?) {
@@ -75,8 +77,7 @@ public struct InitializationResponse : Codable, Hashable, Sendable {
 	}
 }
 
-
 public struct InitializedParams: Codable, Hashable, Sendable {
-    public init() {
-    }
+	public init() {
+	}
 }

--- a/Sources/LanguageServerProtocol/LanguageFeatures/CallHeirarchy.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/CallHeirarchy.swift
@@ -4,14 +4,18 @@ public typealias CallHierarchyClientCapabilities = DynamicRegistrationClientCapa
 
 public typealias CallHierarchyOptions = WorkDoneProgressOptions
 
-public typealias CallHierarchyRegistrationOptions = StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
+public typealias CallHierarchyRegistrationOptions =
+	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
 public struct CallHierarchyPrepareParams: Codable, Hashable, Sendable {
 	public let textDocument: TextDocumentIdentifier
 	public let position: Position
 	public let workDoneToken: ProgressToken?
 
-	public init(textDocument: TextDocumentIdentifier, position: Position, workDoneToken: ProgressToken? = nil) {
+	public init(
+		textDocument: TextDocumentIdentifier, position: Position,
+		workDoneToken: ProgressToken? = nil
+	) {
 		self.textDocument = textDocument
 		self.position = position
 		self.workDoneToken = workDoneToken
@@ -28,14 +32,16 @@ public struct CallHierarchyItem: Codable, Hashable, Sendable {
 	public let selectionRange: LSPRange
 	public let data: LSPAny?
 
-	public init(name: String,
-				kind: SymbolKind,
-				tag: [SymbolTag]? = nil,
-				detail: String? = nil,
-				uri: DocumentUri,
-				range: LSPRange,
-				selectionRange: LSPRange,
-				data: LSPAny? = nil) {
+	public init(
+		name: String,
+		kind: SymbolKind,
+		tag: [SymbolTag]? = nil,
+		detail: String? = nil,
+		uri: DocumentUri,
+		range: LSPRange,
+		selectionRange: LSPRange,
+		data: LSPAny? = nil
+	) {
 		self.name = name
 		self.kind = kind
 		self.tag = tag
@@ -55,7 +61,10 @@ public struct CallHierarchyIncomingCallsParams: Codable, Hashable, Sendable {
 
 	public let item: CallHierarchyItem
 
-	public init(item: CallHierarchyItem, workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil) {
+	public init(
+		item: CallHierarchyItem, workDoneToken: ProgressToken? = nil,
+		partialResultToken: ProgressToken? = nil
+	) {
 		self.workDoneToken = workDoneToken
 		self.partialResultToken = partialResultToken
 		self.item = item

--- a/Sources/LanguageServerProtocol/LanguageFeatures/CodeAction.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/CodeAction.swift
@@ -3,57 +3,59 @@ import Foundation
 public typealias CodeActionKind = String
 
 extension CodeActionKind {
-    public static let Empty: CodeActionKind = ""
-    public static let Quickfix: CodeActionKind = "quickfix"
-    public static let Refactor: CodeActionKind = "refactor"
-    public static let RefactorExtract: CodeActionKind = "refactor.extract"
-    public static let RefactorInline: CodeActionKind = "refactor.inline"
-    public static let RefactorRewrite: CodeActionKind = "refactor.rewrite"
-    public static let Source: CodeActionKind = "source"
-    public static let SourceOrganizeImports: CodeActionKind = "source.organizeImports"
+	public static let Empty: CodeActionKind = ""
+	public static let Quickfix: CodeActionKind = "quickfix"
+	public static let Refactor: CodeActionKind = "refactor"
+	public static let RefactorExtract: CodeActionKind = "refactor.extract"
+	public static let RefactorInline: CodeActionKind = "refactor.inline"
+	public static let RefactorRewrite: CodeActionKind = "refactor.rewrite"
+	public static let Source: CodeActionKind = "source"
+	public static let SourceOrganizeImports: CodeActionKind = "source.organizeImports"
 	public static let SourceFixAll: CodeActionKind = "source.fixAll"
 }
 
 public struct CodeActionClientCapabilities: Codable, Hashable, Sendable {
-    public struct CodeActionLiteralSupport: Codable, Hashable, Sendable {
-        public var codeActionKind: ValueSet<CodeActionKind>
+	public struct CodeActionLiteralSupport: Codable, Hashable, Sendable {
+		public var codeActionKind: ValueSet<CodeActionKind>
 
-        public init(codeActionKind: ValueSet<CodeActionKind>) {
-            self.codeActionKind = codeActionKind
-        }
-    }
+		public init(codeActionKind: ValueSet<CodeActionKind>) {
+			self.codeActionKind = codeActionKind
+		}
+	}
 
-    public struct ResolveSupport: Codable, Hashable, Sendable {
-        public var properties: [String]
+	public struct ResolveSupport: Codable, Hashable, Sendable {
+		public var properties: [String]
 
-        public init(properties: [String]) {
-            self.properties = properties
-        }
-    }
+		public init(properties: [String]) {
+			self.properties = properties
+		}
+	}
 
-    public var dynamicRegistration: Bool?
-    public var codeActionLiteralSupport:CodeActionLiteralSupport?
-    public var isPreferredSupport: Bool?
-    public var disabledSupport: Bool?
-    public var dataSupport: Bool?
-    public var resolveSupport: ResolveSupport?
-    public var honorsChangeAnnotations: Bool?
+	public var dynamicRegistration: Bool?
+	public var codeActionLiteralSupport: CodeActionLiteralSupport?
+	public var isPreferredSupport: Bool?
+	public var disabledSupport: Bool?
+	public var dataSupport: Bool?
+	public var resolveSupport: ResolveSupport?
+	public var honorsChangeAnnotations: Bool?
 
-    public init(dynamicRegistration: Bool?,
-                codeActionLiteralSupport: CodeActionClientCapabilities.CodeActionLiteralSupport? = nil,
-                isPreferredSupport: Bool? = nil,
-                disabledSupport: Bool? = nil,
-                dataSupport: Bool? = nil,
-                resolveSupport: ResolveSupport? = nil,
-                honorsChangeAnnotations: Bool? = nil) {
-        self.dynamicRegistration = dynamicRegistration
-        self.codeActionLiteralSupport = codeActionLiteralSupport
-        self.isPreferredSupport = isPreferredSupport
-        self.disabledSupport = disabledSupport
-        self.dataSupport = dataSupport
-        self.resolveSupport = resolveSupport
-        self.honorsChangeAnnotations = honorsChangeAnnotations
-    }
+	public init(
+		dynamicRegistration: Bool?,
+		codeActionLiteralSupport: CodeActionClientCapabilities.CodeActionLiteralSupport? = nil,
+		isPreferredSupport: Bool? = nil,
+		disabledSupport: Bool? = nil,
+		dataSupport: Bool? = nil,
+		resolveSupport: ResolveSupport? = nil,
+		honorsChangeAnnotations: Bool? = nil
+	) {
+		self.dynamicRegistration = dynamicRegistration
+		self.codeActionLiteralSupport = codeActionLiteralSupport
+		self.isPreferredSupport = isPreferredSupport
+		self.disabledSupport = disabledSupport
+		self.dataSupport = dataSupport
+		self.resolveSupport = resolveSupport
+		self.honorsChangeAnnotations = honorsChangeAnnotations
+	}
 }
 
 public struct CodeActionOptions: Codable, Hashable, Sendable {
@@ -61,7 +63,8 @@ public struct CodeActionOptions: Codable, Hashable, Sendable {
 	public var codeActionKinds: [CodeActionKind]?
 	public var resolveProvider: Bool?
 
-	public init(workDoneProgress: Bool?, codeActionKinds: [CodeActionKind]?, resolveProvider: Bool) {
+	public init(workDoneProgress: Bool?, codeActionKinds: [CodeActionKind]?, resolveProvider: Bool)
+	{
 		self.workDoneProgress = workDoneProgress
 		self.codeActionKinds = codeActionKinds
 		self.resolveProvider = resolveProvider
@@ -74,53 +77,60 @@ public enum CodeActionTriggerKind: Int, Codable, Hashable, Sendable {
 }
 
 public struct CodeActionContext: Codable, Hashable, Sendable {
-    public let diagnostics: [Diagnostic]
-    public let only: [CodeActionKind]?
+	public let diagnostics: [Diagnostic]
+	public let only: [CodeActionKind]?
 	public let triggerKind: CodeActionTriggerKind?
 
-    public init(diagnostics: [Diagnostic], only: [CodeActionKind]?, triggerKind: CodeActionTriggerKind? = nil) {
-        self.diagnostics = diagnostics
-        self.only = only
+	public init(
+		diagnostics: [Diagnostic], only: [CodeActionKind]?,
+		triggerKind: CodeActionTriggerKind? = nil
+	) {
+		self.diagnostics = diagnostics
+		self.only = only
 		self.triggerKind = triggerKind
-    }
+	}
 }
 
 public struct CodeActionParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
-    public let range: LSPRange
-    public let context: CodeActionContext
+	public let textDocument: TextDocumentIdentifier
+	public let range: LSPRange
+	public let context: CodeActionContext
 
-    public init(textDocument: TextDocumentIdentifier, range: LSPRange, context: CodeActionContext) {
-        self.textDocument = textDocument
-        self.range = range
-        self.context = context
-    }
+	public init(textDocument: TextDocumentIdentifier, range: LSPRange, context: CodeActionContext) {
+		self.textDocument = textDocument
+		self.range = range
+		self.context = context
+	}
 }
 
 public struct CodeAction: Codable, Hashable, Sendable {
-    public struct Disabled: Codable, Hashable, Sendable {
-        public var disabled: Bool
-    }
+	public struct Disabled: Codable, Hashable, Sendable {
+		public var disabled: Bool
+	}
 
-    public var title: String
-    public var kind: CodeActionKind?
-    public var diagnostics: [Diagnostic]?
-    public var isPreferred: Bool?
-    public var disabled: Disabled?
-    public var edit: WorkspaceEdit?
-    public var command: Command?
-    public var data: LSPAny?
+	public var title: String
+	public var kind: CodeActionKind?
+	public var diagnostics: [Diagnostic]?
+	public var isPreferred: Bool?
+	public var disabled: Disabled?
+	public var edit: WorkspaceEdit?
+	public var command: Command?
+	public var data: LSPAny?
 
-    public init(title: String, kind: CodeActionKind? = nil, diagnostics: [Diagnostic]? = nil, isPreferred: Bool? = nil, disabled: CodeAction.Disabled? = nil, edit: WorkspaceEdit? = nil, command: Command? = nil, data: LSPAny? = nil) {
-        self.title = title
-        self.kind = kind
-        self.diagnostics = diagnostics
-        self.isPreferred = isPreferred
-        self.disabled = disabled
-        self.edit = edit
-        self.command = command
-        self.data = data
-    }
+	public init(
+		title: String, kind: CodeActionKind? = nil, diagnostics: [Diagnostic]? = nil,
+		isPreferred: Bool? = nil, disabled: CodeAction.Disabled? = nil, edit: WorkspaceEdit? = nil,
+		command: Command? = nil, data: LSPAny? = nil
+	) {
+		self.title = title
+		self.kind = kind
+		self.diagnostics = diagnostics
+		self.isPreferred = isPreferred
+		self.disabled = disabled
+		self.edit = edit
+		self.command = command
+		self.data = data
+	}
 }
 
 public typealias CodeActionResponse = [TwoTypeOption<Command, CodeAction>]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/CodeLens.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/CodeLens.swift
@@ -3,40 +3,43 @@ import Foundation
 public typealias CodeLensClientCapabilities = DynamicRegistrationClientCapabilities
 
 public struct CodeLensWorkspaceClientCapabilities: Codable, Hashable, Sendable {
-    public var refreshSupport: Bool?
+	public var refreshSupport: Bool?
 
-    public init(refreshSupport: Bool? = nil) {
-        self.refreshSupport = refreshSupport
-    }
+	public init(refreshSupport: Bool? = nil) {
+		self.refreshSupport = refreshSupport
+	}
 }
 
 public struct CodeLensOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var resolveProvider: Bool?
+	public var workDoneProgress: Bool?
+	public var resolveProvider: Bool?
 }
 
 public struct CodeLensRegistrationOptions: Codable, Hashable, Sendable {
-    public var documentSelector: DocumentSelector?
-    public var workDoneProgress: Bool?
-    public var resolveProvider: Bool?
+	public var documentSelector: DocumentSelector?
+	public var workDoneProgress: Bool?
+	public var resolveProvider: Bool?
 }
 
 public struct CodeLensParams: Codable, Hashable, Sendable {
-    public var textDocument: TextDocumentIdentifier
-    public var workDoneToken: ProgressToken?
-    public var partialResultToken: ProgressToken?
+	public var textDocument: TextDocumentIdentifier
+	public var workDoneToken: ProgressToken?
+	public var partialResultToken: ProgressToken?
 
-    public init(textDocument: TextDocumentIdentifier, workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil) {
-        self.textDocument = textDocument
-        self.workDoneToken = workDoneToken
-        self.partialResultToken = partialResultToken
-    }
+	public init(
+		textDocument: TextDocumentIdentifier, workDoneToken: ProgressToken? = nil,
+		partialResultToken: ProgressToken? = nil
+	) {
+		self.textDocument = textDocument
+		self.workDoneToken = workDoneToken
+		self.partialResultToken = partialResultToken
+	}
 }
 
 public struct CodeLens: Codable, Hashable, Sendable {
-    public var range: LSPRange
-    public var command: Command?
-    public var data: LSPAny?
+	public var range: LSPRange
+	public var command: Command?
+	public var data: LSPAny?
 }
 
 public typealias CodeLensResponse = [CodeLens]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/ColorPresentation.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/ColorPresentation.swift
@@ -1,25 +1,28 @@
 import Foundation
 
 public struct ColorPresentationParams: Codable, Hashable, Sendable {
-    public let workDoneToken: ProgressToken?
-    public let partialResultToken: ProgressToken?
-    public let textDocument: TextDocumentIdentifier
-    public let color: Color
-    public let range: LSPRange
+	public let workDoneToken: ProgressToken?
+	public let partialResultToken: ProgressToken?
+	public let textDocument: TextDocumentIdentifier
+	public let color: Color
+	public let range: LSPRange
 
-    public init(workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil, textDocument: TextDocumentIdentifier, color: Color, range: LSPRange) {
-        self.workDoneToken = workDoneToken
-        self.partialResultToken = partialResultToken
-        self.textDocument = textDocument
-        self.color = color
-        self.range = range
-    }
+	public init(
+		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil,
+		textDocument: TextDocumentIdentifier, color: Color, range: LSPRange
+	) {
+		self.workDoneToken = workDoneToken
+		self.partialResultToken = partialResultToken
+		self.textDocument = textDocument
+		self.color = color
+		self.range = range
+	}
 }
 
 public struct ColorPresentation: Codable, Hashable, Sendable {
-    public let label: String
-    public let textEdit: TextEdit?
-    public let additionalTextEdits: [TextEdit]?
+	public let label: String
+	public let textEdit: TextEdit?
+	public let additionalTextEdits: [TextEdit]?
 }
 
 public typealias ColorPresentationResponse = [ColorPresentation]

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Completion.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Completion.swift
@@ -2,231 +2,242 @@ import Foundation
 import JSONRPC
 
 public struct CompletionClientCapabilities: Codable, Hashable, Sendable {
-    public struct CompletionItem: Codable, Hashable, Sendable {
-        public struct ResolveSupport: Codable, Hashable, Sendable {
-            public var properties: [String]
+	public struct CompletionItem: Codable, Hashable, Sendable {
+		public struct ResolveSupport: Codable, Hashable, Sendable {
+			public var properties: [String]
 
-            public init(properties: [String]) {
-                self.properties = properties
-            }
-        }
+			public init(properties: [String]) {
+				self.properties = properties
+			}
+		}
 
-        public let snippetSupport: Bool?
-        public let commitCharactersSupport: Bool?
-        public let documentationFormat: [MarkupKind]?
-        public let deprecatedSupport: Bool?
-        public let preselectSupport: Bool?
-        public var tagSupport: ValueSet<CompletionItemTag>?
-        public var insertReplaceSupport: Bool?
-        public var resolveSupport: ResolveSupport?
-        public var insertTextModeSupport: ValueSet<InsertTextMode>?
-        public var labelDetailsSupport: Bool?
+		public let snippetSupport: Bool?
+		public let commitCharactersSupport: Bool?
+		public let documentationFormat: [MarkupKind]?
+		public let deprecatedSupport: Bool?
+		public let preselectSupport: Bool?
+		public var tagSupport: ValueSet<CompletionItemTag>?
+		public var insertReplaceSupport: Bool?
+		public var resolveSupport: ResolveSupport?
+		public var insertTextModeSupport: ValueSet<InsertTextMode>?
+		public var labelDetailsSupport: Bool?
 
-        public init(snippetSupport: Bool? = nil,
-                    commitCharactersSupport: Bool? = nil,
-                    documentationFormat: [MarkupKind]? = nil,
-                    deprecatedSupport: Bool? = nil,
-                    preselectSupport: Bool? = nil,
-                    tagSupport: ValueSet<CompletionItemTag>? = nil,
-                    insertReplaceSupport: Bool? = nil,
-                    resolveSupport: CompletionItem.ResolveSupport? = nil,
-                    insertTextModeSupport: ValueSet<InsertTextMode>? = nil,
-                    labelDetailsSupport: Bool? = nil) {
-            self.snippetSupport = snippetSupport
-            self.commitCharactersSupport = commitCharactersSupport
-            self.documentationFormat = documentationFormat
-            self.deprecatedSupport = deprecatedSupport
-            self.preselectSupport = preselectSupport
-            self.tagSupport = tagSupport
-            self.insertReplaceSupport = insertReplaceSupport
-            self.resolveSupport = resolveSupport
-            self.insertTextModeSupport = insertTextModeSupport
-            self.labelDetailsSupport = labelDetailsSupport
-        }
-    }
+		public init(
+			snippetSupport: Bool? = nil,
+			commitCharactersSupport: Bool? = nil,
+			documentationFormat: [MarkupKind]? = nil,
+			deprecatedSupport: Bool? = nil,
+			preselectSupport: Bool? = nil,
+			tagSupport: ValueSet<CompletionItemTag>? = nil,
+			insertReplaceSupport: Bool? = nil,
+			resolveSupport: CompletionItem.ResolveSupport? = nil,
+			insertTextModeSupport: ValueSet<InsertTextMode>? = nil,
+			labelDetailsSupport: Bool? = nil
+		) {
+			self.snippetSupport = snippetSupport
+			self.commitCharactersSupport = commitCharactersSupport
+			self.documentationFormat = documentationFormat
+			self.deprecatedSupport = deprecatedSupport
+			self.preselectSupport = preselectSupport
+			self.tagSupport = tagSupport
+			self.insertReplaceSupport = insertReplaceSupport
+			self.resolveSupport = resolveSupport
+			self.insertTextModeSupport = insertTextModeSupport
+			self.labelDetailsSupport = labelDetailsSupport
+		}
+	}
 
-    public struct CompletionList: Codable, Hashable, Sendable {
-        public var itemDefaults: [String]?
+	public struct CompletionList: Codable, Hashable, Sendable {
+		public var itemDefaults: [String]?
 
-        public init(itemDefaults: [String]? = nil) {
-            self.itemDefaults = itemDefaults
-        }
-    }
+		public init(itemDefaults: [String]? = nil) {
+			self.itemDefaults = itemDefaults
+		}
+	}
 
-    public var dynamicRegistration: Bool?
-    public var completionItem: CompletionItem?
-    public var completionItemKind: ValueSet<CompletionItemKind>?
-    public var contextSupport: Bool?
-    public var insertTextMode: InsertTextMode?
-    public var completionList: CompletionList?
+	public var dynamicRegistration: Bool?
+	public var completionItem: CompletionItem?
+	public var completionItemKind: ValueSet<CompletionItemKind>?
+	public var contextSupport: Bool?
+	public var insertTextMode: InsertTextMode?
+	public var completionList: CompletionList?
 
-    public init(dynamicRegistration: Bool? = nil,
-                completionItem: CompletionItem? = nil,
-                completionItemKind: ValueSet<CompletionItemKind>? = nil,
-                contextSupport: Bool? = nil,
-                insertTextMode: InsertTextMode? = nil,
-                completionList: CompletionClientCapabilities.CompletionList? = nil) {
-        self.dynamicRegistration = dynamicRegistration
-        self.completionItem = completionItem
-        self.completionItemKind = completionItemKind
-        self.contextSupport = contextSupport
-        self.insertTextMode = insertTextMode
-        self.completionList = completionList
-    }
+	public init(
+		dynamicRegistration: Bool? = nil,
+		completionItem: CompletionItem? = nil,
+		completionItemKind: ValueSet<CompletionItemKind>? = nil,
+		contextSupport: Bool? = nil,
+		insertTextMode: InsertTextMode? = nil,
+		completionList: CompletionClientCapabilities.CompletionList? = nil
+	) {
+		self.dynamicRegistration = dynamicRegistration
+		self.completionItem = completionItem
+		self.completionItemKind = completionItemKind
+		self.contextSupport = contextSupport
+		self.insertTextMode = insertTextMode
+		self.completionList = completionList
+	}
 }
 
 public enum CompletionTriggerKind: Int, Codable, Hashable, Sendable {
-    case invoked = 1
-    case triggerCharacter = 2
-    case triggerForIncompleteCompletions = 3
+	case invoked = 1
+	case triggerCharacter = 2
+	case triggerForIncompleteCompletions = 3
 }
 
 public enum CompletionItemKind: Int, CaseIterable, Codable, Hashable, Sendable {
-    case text = 1
-    case method = 2
-    case function = 3
-    case constructor = 4
-    case field = 5
-    case variable = 6
-    case `class` = 7
-    case interface = 8
-    case module = 9
-    case property = 10
-    case unit = 11
-    case value = 12
-    case `enum` = 13
-    case keyword = 14
-    case snippet = 15
-    case color = 16
-    case file = 17
-    case reference = 18
-    case folder = 19
-    case enumMember = 20
-    case constant = 21
-    case `struct` = 22
-    case event = 23
-    case `operator` = 24
-    case typeParameter = 25
+	case text = 1
+	case method = 2
+	case function = 3
+	case constructor = 4
+	case field = 5
+	case variable = 6
+	case `class` = 7
+	case interface = 8
+	case module = 9
+	case property = 10
+	case unit = 11
+	case value = 12
+	case `enum` = 13
+	case keyword = 14
+	case snippet = 15
+	case color = 16
+	case file = 17
+	case reference = 18
+	case folder = 19
+	case enumMember = 20
+	case constant = 21
+	case `struct` = 22
+	case event = 23
+	case `operator` = 24
+	case typeParameter = 25
 }
 
 public enum CompletionItemTag: Int, CaseIterable, Codable, Hashable, Sendable {
-    case deprecated = 1
+	case deprecated = 1
 }
 
 public struct CompletionContext: Codable, Hashable, Sendable {
-    public let triggerKind: CompletionTriggerKind
-    public let triggerCharacter: String?
+	public let triggerKind: CompletionTriggerKind
+	public let triggerCharacter: String?
 
-    public init(triggerKind: CompletionTriggerKind, triggerCharacter: String?) {
-        self.triggerKind = triggerKind
-        self.triggerCharacter = triggerCharacter
-    }
+	public init(triggerKind: CompletionTriggerKind, triggerCharacter: String?) {
+		self.triggerKind = triggerKind
+		self.triggerCharacter = triggerCharacter
+	}
 }
 
 public struct CompletionParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
-    public let position: Position
-    public let context: CompletionContext?
+	public let textDocument: TextDocumentIdentifier
+	public let position: Position
+	public let context: CompletionContext?
 
-    public init(textDocument: TextDocumentIdentifier, position: Position, context: CompletionContext?) {
-        self.textDocument = textDocument
-        self.position = position
-        self.context = context
-    }
+	public init(
+		textDocument: TextDocumentIdentifier, position: Position, context: CompletionContext?
+	) {
+		self.textDocument = textDocument
+		self.position = position
+		self.context = context
+	}
 
-    public init(uri: DocumentUri, position: Position, triggerKind: CompletionTriggerKind, triggerCharacter: String?) {
-        let td = TextDocumentIdentifier(uri: uri)
-        let ctx = CompletionContext(triggerKind: triggerKind, triggerCharacter: triggerCharacter)
+	public init(
+		uri: DocumentUri, position: Position, triggerKind: CompletionTriggerKind,
+		triggerCharacter: String?
+	) {
+		let td = TextDocumentIdentifier(uri: uri)
+		let ctx = CompletionContext(triggerKind: triggerKind, triggerCharacter: triggerCharacter)
 
-        self.init(textDocument: td, position: position, context: ctx)
-    }
+		self.init(textDocument: td, position: position, context: ctx)
+	}
 }
 
 public enum InsertTextFormat: Int, Codable, Hashable, Sendable {
-    case plaintext = 1
-    case snippet = 2
+	case plaintext = 1
+	case snippet = 2
 }
 
 public struct CompletionItem: Codable, Hashable, Sendable {
-    public let label: String
-    public let kind: CompletionItemKind?
-    public let detail: String?
-    public let documentation: TwoTypeOption<String, MarkupContent>?
-    public let deprecated: Bool?
-    public let preselect: Bool?
-    public let sortText: String?
-    public let filterText: String?
-    public let insertText: String?
-    public let insertTextFormat: InsertTextFormat?
-    public let textEdit: TextEdit?
-    public let additionalTextEdits: [TextEdit]?
-    public let commitCharacters: [String]?
-    public let command: Command?
-    public let data: LSPAny?
+	public let label: String
+	public let kind: CompletionItemKind?
+	public let detail: String?
+	public let documentation: TwoTypeOption<String, MarkupContent>?
+	public let deprecated: Bool?
+	public let preselect: Bool?
+	public let sortText: String?
+	public let filterText: String?
+	public let insertText: String?
+	public let insertTextFormat: InsertTextFormat?
+	public let textEdit: TextEdit?
+	public let additionalTextEdits: [TextEdit]?
+	public let commitCharacters: [String]?
+	public let command: Command?
+	public let data: LSPAny?
 
-    public init(label: String,
-                kind: CompletionItemKind? = nil,
-                detail: String? = nil,
-                documentation: TwoTypeOption<String, MarkupContent>? = nil,
-                deprecated: Bool? = nil,
-                preselect: Bool? = nil,
-                sortText: String? = nil,
-                filterText: String? = nil,
-                insertText: String? = nil,
-                insertTextFormat: InsertTextFormat? = nil,
-                textEdit: TextEdit? = nil,
-                additionalTextEdits: [TextEdit]? = nil,
-                commitCharacters: [String]? = nil,
-                command: Command? = nil,
-                data: LSPAny? = nil) {
-        self.label = label
-        self.kind = kind
-        self.detail = detail
-        self.documentation = documentation
-        self.deprecated = deprecated
-        self.preselect = preselect
-        self.sortText = sortText
-        self.filterText = filterText
-        self.insertText = insertText
-        self.insertTextFormat = insertTextFormat
-        self.textEdit = textEdit
-        self.additionalTextEdits = additionalTextEdits
-        self.commitCharacters = commitCharacters
-        self.command = command
-        self.data = data
-    }
+	public init(
+		label: String,
+		kind: CompletionItemKind? = nil,
+		detail: String? = nil,
+		documentation: TwoTypeOption<String, MarkupContent>? = nil,
+		deprecated: Bool? = nil,
+		preselect: Bool? = nil,
+		sortText: String? = nil,
+		filterText: String? = nil,
+		insertText: String? = nil,
+		insertTextFormat: InsertTextFormat? = nil,
+		textEdit: TextEdit? = nil,
+		additionalTextEdits: [TextEdit]? = nil,
+		commitCharacters: [String]? = nil,
+		command: Command? = nil,
+		data: LSPAny? = nil
+	) {
+		self.label = label
+		self.kind = kind
+		self.detail = detail
+		self.documentation = documentation
+		self.deprecated = deprecated
+		self.preselect = preselect
+		self.sortText = sortText
+		self.filterText = filterText
+		self.insertText = insertText
+		self.insertTextFormat = insertTextFormat
+		self.textEdit = textEdit
+		self.additionalTextEdits = additionalTextEdits
+		self.commitCharacters = commitCharacters
+		self.command = command
+		self.data = data
+	}
 }
 
 public struct CompletionList: Codable, Hashable, Sendable {
-    public let isIncomplete: Bool
-    public let items: [CompletionItem]
+	public let isIncomplete: Bool
+	public let items: [CompletionItem]
 
-    public init(isIncomplete: Bool, items: [CompletionItem]) {
-        self.isIncomplete = isIncomplete
-        self.items = items
-    }
+	public init(isIncomplete: Bool, items: [CompletionItem]) {
+		self.isIncomplete = isIncomplete
+		self.items = items
+	}
 }
 
 public typealias CompletionResponse = TwoTypeOption<[CompletionItem], CompletionList>?
 
-public extension TwoTypeOption where T == [CompletionItem], U == CompletionList {
-    var items: [CompletionItem] {
-        switch self {
-        case .optionA(let v):
-            return v
-        case .optionB(let list):
-            return list.items
-        }
-    }
+extension TwoTypeOption where T == [CompletionItem], U == CompletionList {
+	public var items: [CompletionItem] {
+		switch self {
+		case .optionA(let v):
+			return v
+		case .optionB(let list):
+			return list.items
+		}
+	}
 
-    var isIncomplete: Bool {
-        switch self {
-        case .optionA:
-            return false
-        case .optionB(let value):
-            return value.isIncomplete
-        }
-    }
+	public var isIncomplete: Bool {
+		switch self {
+		case .optionA:
+			return false
+		case .optionB(let value):
+			return value.isIncomplete
+		}
+	}
 }
 
 public struct CompletionRegistrationOptions: Codable {
@@ -236,7 +247,6 @@ public struct CompletionRegistrationOptions: Codable {
 }
 
 public enum InsertTextMode: Int, CaseIterable, Codable, Hashable, Sendable {
-    case asIs = 1
-    case adjustIndentation = 2
+	case asIs = 1
+	case adjustIndentation = 2
 }
-

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Declaration.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Declaration.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Matthew Massicotte on 2022-02-17.
 //

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Diagnostics.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Diagnostics.swift
@@ -6,7 +6,10 @@ public struct DiagnosticOptions: Codable, Hashable, Sendable {
 	public let interFileDependencies: Bool
 	public let workspaceDiagnostics: Bool
 
-	public init(workDoneProgress: Bool? = nil, identifier: String? = nil, interFileDependencies: Bool, workspaceDiagnostics: Bool) {
+	public init(
+		workDoneProgress: Bool? = nil, identifier: String? = nil, interFileDependencies: Bool,
+		workspaceDiagnostics: Bool
+	) {
 		self.workDoneProgress = workDoneProgress
 		self.identifier = identifier
 		self.interFileDependencies = interFileDependencies
@@ -22,7 +25,11 @@ public struct DiagnosticRegistrationOptions: Codable, Hashable, Sendable {
 	public let workspaceDiagnostics: Bool
 	public let id: String?
 
-	public init(documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil, identifier: String? = nil, interFileDependencies: Bool, workspaceDiagnostics: Bool, id: String? = nil) {
+	public init(
+		documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil,
+		identifier: String? = nil, interFileDependencies: Bool, workspaceDiagnostics: Bool,
+		id: String? = nil
+	) {
 		self.documentSelector = documentSelector
 		self.workDoneProgress = workDoneProgress
 		self.identifier = identifier
@@ -33,19 +40,22 @@ public struct DiagnosticRegistrationOptions: Codable, Hashable, Sendable {
 }
 
 public struct PublishDiagnosticsClientCapabilities: Codable, Hashable, Sendable {
-    public var relatedInformation: Bool?
-    public var tagSupport: ValueSet<DiagnosticTag>?
-    public var versionSupport: Bool?
-    public var codeDescriptionSupport: Bool?
-    public var dataSupport: Bool?
+	public var relatedInformation: Bool?
+	public var tagSupport: ValueSet<DiagnosticTag>?
+	public var versionSupport: Bool?
+	public var codeDescriptionSupport: Bool?
+	public var dataSupport: Bool?
 
-    public init(relatedInformation: Bool? = nil, tagSupport: ValueSet<DiagnosticTag>? = nil, versionSupport: Bool? = nil, codeDescriptionSupport: Bool? = nil, dataSupport: Bool? = nil) {
-        self.relatedInformation = relatedInformation
-        self.tagSupport = tagSupport
-        self.versionSupport = versionSupport
-        self.codeDescriptionSupport = codeDescriptionSupport
-        self.dataSupport = dataSupport
-    }
+	public init(
+		relatedInformation: Bool? = nil, tagSupport: ValueSet<DiagnosticTag>? = nil,
+		versionSupport: Bool? = nil, codeDescriptionSupport: Bool? = nil, dataSupport: Bool? = nil
+	) {
+		self.relatedInformation = relatedInformation
+		self.tagSupport = tagSupport
+		self.versionSupport = versionSupport
+		self.codeDescriptionSupport = codeDescriptionSupport
+		self.dataSupport = dataSupport
+	}
 }
 
 public struct DiagnosticClientCapabilities: Codable, Hashable, Sendable {
@@ -59,8 +69,8 @@ public struct DiagnosticClientCapabilities: Codable, Hashable, Sendable {
 }
 
 public struct DiagnosticRelatedInformation: Codable, Hashable, Sendable {
-    public let location: Location
-    public let message: String
+	public let location: Location
+	public let message: String
 
 	public init(location: Location, message: String) {
 		self.location = location
@@ -71,45 +81,49 @@ public struct DiagnosticRelatedInformation: Codable, Hashable, Sendable {
 public typealias DiagnosticCode = TwoTypeOption<Int, String>
 
 public enum DiagnosticSeverity: Int, CaseIterable, Codable, Hashable, Sendable {
-    case error = 1
-    case warning = 2
-    case information = 3
-    case hint = 4
+	case error = 1
+	case warning = 2
+	case information = 3
+	case hint = 4
 }
 
 public enum DiagnosticTag: Int, CaseIterable, Codable, Hashable, Sendable {
-    case unnecessary = 1
-    case deprecated = 2
+	case unnecessary = 1
+	case deprecated = 2
 }
 
 public typealias CodeDescription = String
 
 public struct Diagnostic: Codable, Hashable, Sendable {
-    public let range: LSPRange
-    public let severity: DiagnosticSeverity?
-    public let code: DiagnosticCode?
+	public let range: LSPRange
+	public let severity: DiagnosticSeverity?
+	public let code: DiagnosticCode?
 	public let codeDescription: CodeDescription?
-    public let source: String?
-    public let message: String
-    public let tags: [DiagnosticTag]?
-    public let relatedInformation: [DiagnosticRelatedInformation]?
+	public let source: String?
+	public let message: String
+	public let tags: [DiagnosticTag]?
+	public let relatedInformation: [DiagnosticRelatedInformation]?
 
-    public init(range: LSPRange, severity: DiagnosticSeverity? = nil, code: DiagnosticCode? = nil, codeDescription: CodeDescription? = nil, source: String? = nil, message: String, tags: [DiagnosticTag]? = nil, relatedInformation: [DiagnosticRelatedInformation]? = nil) {
-      self.range = range
-      self.severity = severity
-      self.code = code
-      self.codeDescription = codeDescription
-      self.source = source
-      self.message = message
-      self.tags = tags
-      self.relatedInformation = relatedInformation
-  }
+	public init(
+		range: LSPRange, severity: DiagnosticSeverity? = nil, code: DiagnosticCode? = nil,
+		codeDescription: CodeDescription? = nil, source: String? = nil, message: String,
+		tags: [DiagnosticTag]? = nil, relatedInformation: [DiagnosticRelatedInformation]? = nil
+	) {
+		self.range = range
+		self.severity = severity
+		self.code = code
+		self.codeDescription = codeDescription
+		self.source = source
+		self.message = message
+		self.tags = tags
+		self.relatedInformation = relatedInformation
+	}
 }
 
 public struct PublishDiagnosticsParams: Codable, Hashable, Sendable {
-    public let uri: DocumentUri
-    public let version: Int?
-    public let diagnostics: [Diagnostic]
+	public let uri: DocumentUri
+	public let version: Int?
+	public let diagnostics: [Diagnostic]
 
 	public init(uri: DocumentUri, version: Int? = nil, diagnostics: [Diagnostic]) {
 		self.uri = uri
@@ -150,7 +164,9 @@ public struct BaseDocumentDiagnosticReport: Codable, Hashable, Sendable {
 	public let resultId: String?
 	public let items: [Diagnostic]?
 
-	public init(kind: DocumentDiagnosticReportKind, resultId: String? = nil, items: [Diagnostic]? = nil) {
+	public init(
+		kind: DocumentDiagnosticReportKind, resultId: String? = nil, items: [Diagnostic]? = nil
+	) {
 		self.kind = kind
 		self.resultId = resultId
 		self.items = items
@@ -163,7 +179,10 @@ public struct RelatedDocumentDiagnosticReport: Codable, Hashable, Sendable {
 	public let items: [Diagnostic]?
 	public let relatedDocuments: [DocumentUri: DocumentDiagnosticReport]?
 
-	public init(kind: DocumentDiagnosticReportKind, resultId: String? = nil, items: [Diagnostic]? = nil, relatedDocuments: [DocumentUri : DocumentDiagnosticReport]? = nil) {
+	public init(
+		kind: DocumentDiagnosticReportKind, resultId: String? = nil, items: [Diagnostic]? = nil,
+		relatedDocuments: [DocumentUri: DocumentDiagnosticReport]? = nil
+	) {
 		self.kind = kind
 		self.resultId = resultId
 		self.items = items

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentColor.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentColor.swift
@@ -3,27 +3,30 @@ import Foundation
 public typealias DocumentColorClientCapabilities = DynamicRegistrationClientCapabilities
 
 public struct DocumentColorParams: Codable, Hashable, Sendable {
-    public let workDoneToken: ProgressToken?
-    public let partialResultToken: ProgressToken?
-    public let textDocument: TextDocumentIdentifier
+	public let workDoneToken: ProgressToken?
+	public let partialResultToken: ProgressToken?
+	public let textDocument: TextDocumentIdentifier
 
-    public init(textDocument: TextDocumentIdentifier, workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil) {
-        self.workDoneToken = workDoneToken
-        self.partialResultToken = partialResultToken
-        self.textDocument = textDocument
-    }
+	public init(
+		textDocument: TextDocumentIdentifier, workDoneToken: ProgressToken? = nil,
+		partialResultToken: ProgressToken? = nil
+	) {
+		self.workDoneToken = workDoneToken
+		self.partialResultToken = partialResultToken
+		self.textDocument = textDocument
+	}
 }
 
 public struct Color: Codable, Hashable, Sendable {
-    public let red: Float
-    public let green: Float
-    public let blue: Float
-    public let alpha: Float
+	public let red: Float
+	public let green: Float
+	public let blue: Float
+	public let alpha: Float
 }
 
 public struct ColorInformation: Codable, Hashable, Sendable {
-    public let range: LSPRange
-    public let color: Color
+	public let range: LSPRange
+	public let color: Color
 }
 
 public typealias DocumentColorResponse = [ColorInformation]

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentHighlight.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentHighlight.swift
@@ -5,33 +5,36 @@ public typealias DocumentHighlightClientCapabilities = DynamicRegistrationClient
 public typealias DocumentHighlightOptions = WorkDoneProgressOptions
 
 public struct DocumentHighlightRegistrationOptions: Codable, Hashable, Sendable {
-    public var documentSelector: DocumentSelector?
-    public var workDoneProgress: Bool?
+	public var documentSelector: DocumentSelector?
+	public var workDoneProgress: Bool?
 }
 
 public struct DocumentHighlightParams: Codable, Hashable, Sendable {
-    public var textDocument: TextDocumentIdentifier
-    public var position: Position
-    public var workDoneToken: ProgressToken?
-    public var partialResultToken: ProgressToken?
+	public var textDocument: TextDocumentIdentifier
+	public var position: Position
+	public var workDoneToken: ProgressToken?
+	public var partialResultToken: ProgressToken?
 
-    public init(textDocument: TextDocumentIdentifier, position: Position, workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil) {
-        self.textDocument = textDocument
-        self.position = position
-        self.workDoneToken = workDoneToken
-        self.partialResultToken = partialResultToken
-    }
+	public init(
+		textDocument: TextDocumentIdentifier, position: Position,
+		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil
+	) {
+		self.textDocument = textDocument
+		self.position = position
+		self.workDoneToken = workDoneToken
+		self.partialResultToken = partialResultToken
+	}
 }
 
 public enum DocumentHighlightKind: Int, CaseIterable, Codable, Hashable, Sendable {
-    case Text = 1
-    case Read = 2
-    case Write = 3
+	case Text = 1
+	case Read = 2
+	case Write = 3
 }
 
 public struct DocumentHighlight: Codable, Hashable, Sendable {
-    public var range: LSPRange
-    public var kind: DocumentHighlightKind?
+	public var range: LSPRange
+	public var kind: DocumentHighlightKind?
 }
 
 public typealias DocumentHighlightResponse = [DocumentHighlight]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentLink.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentLink.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Matthew Massicotte on 2022-02-18.
 //
@@ -8,42 +8,45 @@
 import Foundation
 
 public struct DocumentLinkClientCapabilities: Codable, Hashable, Sendable {
-    public var dynamicRegistration: Bool?
-    public var tooltipSupport: Bool?
+	public var dynamicRegistration: Bool?
+	public var tooltipSupport: Bool?
 
-    public init(dynamicRegistration: Bool, tooltipSupport: Bool? = nil) {
-        self.dynamicRegistration = dynamicRegistration
-        self.tooltipSupport = tooltipSupport
-    }
+	public init(dynamicRegistration: Bool, tooltipSupport: Bool? = nil) {
+		self.dynamicRegistration = dynamicRegistration
+		self.tooltipSupport = tooltipSupport
+	}
 }
 
 public struct DocumentLinkOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var resolveProvider: Bool?
+	public var workDoneProgress: Bool?
+	public var resolveProvider: Bool?
 }
 
 public struct DocumentLinkRegistrationOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var documentSelector: DocumentSelector?
-    public var resolveProvider: Bool?
+	public var workDoneProgress: Bool?
+	public var documentSelector: DocumentSelector?
+	public var resolveProvider: Bool?
 
-    public init(workDoneProgress: Bool? = nil, documentSelector: DocumentSelector? = nil, resolveProvider: Bool? = nil) {
-        self.workDoneProgress = workDoneProgress
-        self.documentSelector = documentSelector
-        self.resolveProvider = resolveProvider
-    }
+	public init(
+		workDoneProgress: Bool? = nil, documentSelector: DocumentSelector? = nil,
+		resolveProvider: Bool? = nil
+	) {
+		self.workDoneProgress = workDoneProgress
+		self.documentSelector = documentSelector
+		self.resolveProvider = resolveProvider
+	}
 }
 
 public struct DocumentLinkParams: Codable, Hashable, Sendable {
-    public var workDoneToken: ProgressToken?
-    public var partialResultToken: ProgressToken?
+	public var workDoneToken: ProgressToken?
+	public var partialResultToken: ProgressToken?
 }
 
 public struct DocumentLink: Codable, Hashable, Sendable {
-    public var range: LSPRange
-    public var target: DocumentUri?
-    public var tooltip: String?
-    public var data: LSPAny?
+	public var range: LSPRange
+	public var target: DocumentUri?
+	public var tooltip: String?
+	public var data: LSPAny?
 
 	public init(range: LSPRange, target: DocumentUri?, tooltip: String?, data: LSPAny?) {
 		self.range = range

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentSymbol.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentSymbol.swift
@@ -1,31 +1,38 @@
 import Foundation
 
 public struct DocumentSymbolClientCapabilities: Codable, Hashable, Sendable {
-    public var dynamicRegistration: Bool?
-    public var symbolKind: ValueSet<SymbolKind>?
-    public var hierarchicalDocumentSymbolSupport: Bool?
-    public var tagSupport: ValueSet<SymbolTag>?
-    public var labelSupport: Bool?
+	public var dynamicRegistration: Bool?
+	public var symbolKind: ValueSet<SymbolKind>?
+	public var hierarchicalDocumentSymbolSupport: Bool?
+	public var tagSupport: ValueSet<SymbolTag>?
+	public var labelSupport: Bool?
 
-    public init(dynamicRegistration: Bool, symbolKind: ValueSet<SymbolKind>? = nil, hierarchicalDocumentSymbolSupport: Bool? = nil, tagSupport: ValueSet<SymbolTag>? = nil, labelSupport: Bool? = nil) {
-        self.dynamicRegistration = dynamicRegistration
-        self.symbolKind = symbolKind
-        self.hierarchicalDocumentSymbolSupport = hierarchicalDocumentSymbolSupport
-        self.tagSupport = tagSupport
-        self.labelSupport = labelSupport
-    }
+	public init(
+		dynamicRegistration: Bool, symbolKind: ValueSet<SymbolKind>? = nil,
+		hierarchicalDocumentSymbolSupport: Bool? = nil, tagSupport: ValueSet<SymbolTag>? = nil,
+		labelSupport: Bool? = nil
+	) {
+		self.dynamicRegistration = dynamicRegistration
+		self.symbolKind = symbolKind
+		self.hierarchicalDocumentSymbolSupport = hierarchicalDocumentSymbolSupport
+		self.tagSupport = tagSupport
+		self.labelSupport = labelSupport
+	}
 }
 
 public struct DocumentSymbolParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
+	public let textDocument: TextDocumentIdentifier
 
-    public init(textDocument: TextDocumentIdentifier) {
-        self.textDocument = textDocument
-    }
+	public init(textDocument: TextDocumentIdentifier) {
+		self.textDocument = textDocument
+	}
 }
 
 public struct DocumentSymbol: Codable, Hashable, Sendable {
-	public init(name: String, detail: String? = nil, kind: SymbolKind, deprecated: Bool? = nil, range: LSPRange, selectionRange: LSPRange, children: [DocumentSymbol]? = nil) {
+	public init(
+		name: String, detail: String? = nil, kind: SymbolKind, deprecated: Bool? = nil,
+		range: LSPRange, selectionRange: LSPRange, children: [DocumentSymbol]? = nil
+	) {
 		self.name = name
 		self.detail = detail
 		self.kind = kind
@@ -35,14 +42,13 @@ public struct DocumentSymbol: Codable, Hashable, Sendable {
 		self.children = children
 	}
 
-    public let name: String
-    public let detail: String?
-    public let kind: SymbolKind
-    public let deprecated: Bool?
-    public let range: LSPRange
-    public let selectionRange: LSPRange
-    public let children: [DocumentSymbol]?
+	public let name: String
+	public let detail: String?
+	public let kind: SymbolKind
+	public let deprecated: Bool?
+	public let range: LSPRange
+	public let selectionRange: LSPRange
+	public let children: [DocumentSymbol]?
 }
-
 
 public typealias DocumentSymbolResponse = TwoTypeOption<[DocumentSymbol], [SymbolInformation]>?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/FoldingRange.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/FoldingRange.swift
@@ -1,37 +1,39 @@
 import Foundation
 
 public struct FoldingRangeClientCapabilities: Codable, Hashable, Sendable {
-    public var dynamicRegistration: Bool?
-    public var rangeLimit: Int?
-    public var lineFoldingOnly: Bool?
+	public var dynamicRegistration: Bool?
+	public var rangeLimit: Int?
+	public var lineFoldingOnly: Bool?
 
-    public init(dynamicRegistration: Bool? = nil, rangeLimit: Int? = nil, lineFoldingOnly: Bool? = nil) {
-        self.dynamicRegistration = dynamicRegistration
-        self.rangeLimit = rangeLimit
-        self.lineFoldingOnly = lineFoldingOnly
-    }
+	public init(
+		dynamicRegistration: Bool? = nil, rangeLimit: Int? = nil, lineFoldingOnly: Bool? = nil
+	) {
+		self.dynamicRegistration = dynamicRegistration
+		self.rangeLimit = rangeLimit
+		self.lineFoldingOnly = lineFoldingOnly
+	}
 }
 
 public struct FoldingRangeParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
+	public let textDocument: TextDocumentIdentifier
 
-    public init(textDocument: TextDocumentIdentifier) {
-        self.textDocument = textDocument
-    }
+	public init(textDocument: TextDocumentIdentifier) {
+		self.textDocument = textDocument
+	}
 }
 
 public enum FoldingRangeKind: String, CaseIterable, Codable, Hashable, Sendable {
-    case comment
-    case imports
-    case region
+	case comment
+	case imports
+	case region
 }
 
 public struct FoldingRange: Codable, Hashable, Sendable {
-    public let startLine: Int
-    public let startCharacter: Int?
-    public let endLine: Int
-    public let endCharacter: Int?
-    public let kind: FoldingRangeKind?
+	public let startLine: Int
+	public let startCharacter: Int?
+	public let endLine: Int
+	public let endCharacter: Int?
+	public let kind: FoldingRangeKind?
 }
 
 public typealias FoldingRangeResponse = [FoldingRange]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Formatting.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Formatting.swift
@@ -4,49 +4,52 @@ public typealias DocumentFormattingClientCapabilities = DynamicRegistrationClien
 public typealias DocumentRangeFormattingClientCapabilities = DynamicRegistrationClientCapabilities
 
 public struct FormattingOptions: Codable, Hashable, Sendable {
-    public let tabSize: Int
-    public let insertSpaces: Bool
+	public let tabSize: Int
+	public let insertSpaces: Bool
 
-    public init(tabSize: Int, insertSpaces: Bool) {
-        self.tabSize = tabSize
-        self.insertSpaces = insertSpaces
-    }
+	public init(tabSize: Int, insertSpaces: Bool) {
+		self.tabSize = tabSize
+		self.insertSpaces = insertSpaces
+	}
 }
 
 public struct DocumentFormattingParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
-    public let options: FormattingOptions
+	public let textDocument: TextDocumentIdentifier
+	public let options: FormattingOptions
 
-    public init(textDocument: TextDocumentIdentifier, options: FormattingOptions) {
-        self.textDocument = textDocument
-        self.options = options
-    }
+	public init(textDocument: TextDocumentIdentifier, options: FormattingOptions) {
+		self.textDocument = textDocument
+		self.options = options
+	}
 }
 
 public struct DocumentRangeFormattingParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
-    public let range: LSPRange
-    public let options: FormattingOptions
+	public let textDocument: TextDocumentIdentifier
+	public let range: LSPRange
+	public let options: FormattingOptions
 
-    public init(textDocument: TextDocumentIdentifier, range: LSPRange, options: FormattingOptions) {
-        self.textDocument = textDocument
-        self.range = range
-        self.options = options
-    }
+	public init(textDocument: TextDocumentIdentifier, range: LSPRange, options: FormattingOptions) {
+		self.textDocument = textDocument
+		self.range = range
+		self.options = options
+	}
 }
 
 public struct DocumentOnTypeFormattingParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
-    public let position: Position
-    public let ch: String
-    public let options: FormattingOptions
+	public let textDocument: TextDocumentIdentifier
+	public let position: Position
+	public let ch: String
+	public let options: FormattingOptions
 
-    public init(textDocument: TextDocumentIdentifier, position: Position, ch: String, options: FormattingOptions) {
-        self.textDocument = textDocument
-        self.position = position
-        self.ch = ch
-        self.options = options
-    }
+	public init(
+		textDocument: TextDocumentIdentifier, position: Position, ch: String,
+		options: FormattingOptions
+	) {
+		self.textDocument = textDocument
+		self.position = position
+		self.ch = ch
+		self.options = options
+	}
 }
 
 public typealias FormattingResult = [TextEdit]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Hover.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Hover.swift
@@ -1,20 +1,22 @@
 import Foundation
 
 public struct HoverClientCapabilities: Codable, Hashable, Sendable {
-    public var dynamicRegistration: Bool?
-    public var contentFormat: [MarkupKind]?
+	public var dynamicRegistration: Bool?
+	public var contentFormat: [MarkupKind]?
 
-    public init(dynamicRegistration: Bool?, contentFormat: [MarkupKind]?) {
-        self.dynamicRegistration = dynamicRegistration
-        self.contentFormat = contentFormat
-    }
+	public init(dynamicRegistration: Bool?, contentFormat: [MarkupKind]?) {
+		self.dynamicRegistration = dynamicRegistration
+		self.contentFormat = contentFormat
+	}
 }
 
 public struct Hover: Codable, Hashable, Sendable {
-    public let contents: ThreeTypeOption<MarkedString, [MarkedString], MarkupContent>
-    public let range: LSPRange?
+	public let contents: ThreeTypeOption<MarkedString, [MarkedString], MarkupContent>
+	public let range: LSPRange?
 
-	public init(contents: ThreeTypeOption<MarkedString, [MarkedString], MarkupContent>, range: LSPRange?) {
+	public init(
+		contents: ThreeTypeOption<MarkedString, [MarkedString], MarkupContent>, range: LSPRange?
+	) {
 		self.contents = contents
 		self.range = range
 	}

--- a/Sources/LanguageServerProtocol/LanguageFeatures/References.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/References.swift
@@ -3,30 +3,34 @@ import Foundation
 public typealias ReferenceClientCapabilities = DynamicRegistrationClientCapabilities
 
 public struct ReferenceContext: Codable, Hashable, Sendable {
-    public let includeDeclaration: Bool
+	public let includeDeclaration: Bool
 
-    public init(includeDeclaration: Bool) {
-        self.includeDeclaration = includeDeclaration
-    }
+	public init(includeDeclaration: Bool) {
+		self.includeDeclaration = includeDeclaration
+	}
 }
 
 public struct ReferenceParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
-    public let position: Position
-    public let context: ReferenceContext
+	public let textDocument: TextDocumentIdentifier
+	public let position: Position
+	public let context: ReferenceContext
 
-    public init(textDocument: TextDocumentIdentifier, position: Position,
-                context: ReferenceContext) {
-        self.textDocument = textDocument
-        self.position = position
-        self.context = context
-    }
+	public init(
+		textDocument: TextDocumentIdentifier, position: Position,
+		context: ReferenceContext
+	) {
+		self.textDocument = textDocument
+		self.position = position
+		self.context = context
+	}
 
-    public init(textDocument: TextDocumentIdentifier, position: Position, includeDeclaration: Bool = false) {
-        let ctx = ReferenceContext(includeDeclaration: includeDeclaration)
+	public init(
+		textDocument: TextDocumentIdentifier, position: Position, includeDeclaration: Bool = false
+	) {
+		let ctx = ReferenceContext(includeDeclaration: includeDeclaration)
 
-        self.init(textDocument: textDocument, position: position, context: ctx)
-    }
+		self.init(textDocument: textDocument, position: position, context: ctx)
+	}
 }
 
 public typealias ReferenceResponse = [Location]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Rename.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Rename.swift
@@ -1,52 +1,57 @@
 import Foundation
 
 public enum PrepareSupportDefaultBehavior: Int, CaseIterable, Codable, Hashable, Sendable {
-    case Identifier = 1
+	case Identifier = 1
 }
 
 public struct RenameClientCapabilities: Codable, Hashable, Sendable {
-    public let dynamicRegistration: Bool?
-    public let prepareSupport: Bool?
-    public let prepareSupportDefaultBehavior: PrepareSupportDefaultBehavior?
-    public let honorsChangeAnnotations: Bool?
+	public let dynamicRegistration: Bool?
+	public let prepareSupport: Bool?
+	public let prepareSupportDefaultBehavior: PrepareSupportDefaultBehavior?
+	public let honorsChangeAnnotations: Bool?
 
-    public init(dynamicRegistration: Bool?, prepareSupport: Bool?, prepareSupportDefaultBehavior: PrepareSupportDefaultBehavior?, honorsChangeAnnotations: Bool?) {
-        self.dynamicRegistration = dynamicRegistration
-        self.prepareSupport = prepareSupport
-        self.prepareSupportDefaultBehavior = prepareSupportDefaultBehavior
-        self.honorsChangeAnnotations = honorsChangeAnnotations
-    }
+	public init(
+		dynamicRegistration: Bool?, prepareSupport: Bool?,
+		prepareSupportDefaultBehavior: PrepareSupportDefaultBehavior?,
+		honorsChangeAnnotations: Bool?
+	) {
+		self.dynamicRegistration = dynamicRegistration
+		self.prepareSupport = prepareSupport
+		self.prepareSupportDefaultBehavior = prepareSupportDefaultBehavior
+		self.honorsChangeAnnotations = honorsChangeAnnotations
+	}
 }
 
-
 public struct RenameOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var prepareProvider: Bool?
+	public var workDoneProgress: Bool?
+	public var prepareProvider: Bool?
 }
 
 public typealias PrepareRenameParams = TextDocumentPositionParams
 
 public struct RenameParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
-    public let position: Position
-    public let newName: String
+	public let textDocument: TextDocumentIdentifier
+	public let position: Position
+	public let newName: String
 
-    public init(textDocument: TextDocumentIdentifier, position: Position, newName: String) {
-        self.textDocument = textDocument
-        self.position = position
-        self.newName = newName
-    }
+	public init(textDocument: TextDocumentIdentifier, position: Position, newName: String) {
+		self.textDocument = textDocument
+		self.position = position
+		self.newName = newName
+	}
 }
 
 public struct RangeWithPlaceholder: Codable, Hashable, Sendable {
-    public let range: LSPRange
-    public let placeholder: String
+	public let range: LSPRange
+	public let placeholder: String
 }
 
 public struct PrepareRenameDefaultBehavior: Codable, Hashable, Sendable {
-    public let defaultBehavior: Bool
+	public let defaultBehavior: Bool
 }
 
-public typealias PrepareRenameResponse = ThreeTypeOption<LSPRange, RangeWithPlaceholder, PrepareRenameDefaultBehavior>?
+public typealias PrepareRenameResponse = ThreeTypeOption<
+	LSPRange, RangeWithPlaceholder, PrepareRenameDefaultBehavior
+>?
 
 public typealias RenameResponse = WorkspaceEdit?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/SelectionRange.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/SelectionRange.swift
@@ -4,31 +4,35 @@ public typealias SelectionRangeClientCapabilities = DynamicRegistrationClientCap
 
 public typealias SelectionRangeOptions = WorkDoneProgressOptions
 
-public typealias SelectionRangeRegistrationOptions = StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
+public typealias SelectionRangeRegistrationOptions =
+	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
 public struct SelectionRangeParams: Codable, Hashable, Sendable {
-    public let workDoneToken: ProgressToken?
-    public let partialResultToken: ProgressToken?
-    public let textDocument: TextDocumentIdentifier
-    public let positions: [Position]
+	public let workDoneToken: ProgressToken?
+	public let partialResultToken: ProgressToken?
+	public let textDocument: TextDocumentIdentifier
+	public let positions: [Position]
 
-    public init(workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil, textDocument: TextDocumentIdentifier, positions: [Position]) {
-        self.workDoneToken = workDoneToken
-        self.partialResultToken = partialResultToken
-        self.textDocument = textDocument
-        self.positions = positions
-    }
+	public init(
+		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil,
+		textDocument: TextDocumentIdentifier, positions: [Position]
+	) {
+		self.workDoneToken = workDoneToken
+		self.partialResultToken = partialResultToken
+		self.textDocument = textDocument
+		self.positions = positions
+	}
 }
 
 public final class SelectionRange: Codable, Sendable {
-    public let range: LSPRange
-    public let parent: SelectionRange?
+	public let range: LSPRange
+	public let parent: SelectionRange?
 }
 
 extension SelectionRange: Equatable {
-    public static func == (lhs: SelectionRange, rhs: SelectionRange) -> Bool {
-        return lhs.range == rhs.range && lhs.parent == rhs.parent
-    }
+	public static func == (lhs: SelectionRange, rhs: SelectionRange) -> Bool {
+		return lhs.range == rhs.range && lhs.parent == rhs.parent
+	}
 }
 
 public typealias SelectionRangeResponse = [SelectionRange]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/SemanticTokens.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/SemanticTokens.swift
@@ -1,186 +1,188 @@
 import Foundation
 
 public struct SemanticTokensWorkspaceClientCapabilities: Codable, Hashable, Sendable {
-    public var refreshSupport: Bool?
+	public var refreshSupport: Bool?
 
-    public init(refreshSupport: Bool) {
-        self.refreshSupport = refreshSupport
-    }
+	public init(refreshSupport: Bool) {
+		self.refreshSupport = refreshSupport
+	}
 }
 
 public enum TokenFormat: String, Codable, Hashable, Sendable {
-    case relative = "relative"
+	case relative = "relative"
 
-    public static let Relative = TokenFormat.relative
+	public static let Relative = TokenFormat.relative
 }
 
 public struct SemanticTokensClientCapabilities: Codable, Hashable, Sendable {
-    public struct Requests: Codable, Hashable, Sendable {
-        public struct Range: Codable, Hashable, Sendable {
-        }
+	public struct Requests: Codable, Hashable, Sendable {
+		public struct Range: Codable, Hashable, Sendable {
+		}
 
-        public struct Full: Codable, Hashable, Sendable {
-            public var delta: Bool?
+		public struct Full: Codable, Hashable, Sendable {
+			public var delta: Bool?
 
-            public init(delta: Bool = true) {
-                self.delta = delta
-            }
-        }
+			public init(delta: Bool = true) {
+				self.delta = delta
+			}
+		}
 
-        public typealias RangeOption = TwoTypeOption<Bool, Range>
-        public typealias FullOption = TwoTypeOption<Bool, Full>
+		public typealias RangeOption = TwoTypeOption<Bool, Range>
+		public typealias FullOption = TwoTypeOption<Bool, Full>
 
-        public var range: RangeOption
-        public var full: FullOption
+		public var range: RangeOption
+		public var full: FullOption
 
-        public init(range: Bool = true, delta: Bool = true) {
-            self.range = .optionA(range)
-            self.full = .optionB(Full(delta: true))
-        }
-    }
+		public init(range: Bool = true, delta: Bool = true) {
+			self.range = .optionA(range)
+			self.full = .optionB(Full(delta: true))
+		}
+	}
 
-    public var dynamicRegistration: Bool?
-    public var requests: Requests
-    public var tokenTypes: [String]
-    public var tokenModifiers: [String]
-    public var formats: [TokenFormat]
-    public var overlappingTokenSupport: Bool?
-    public var multilineTokenSupport: Bool?
-    public var serverCancelSupport: Bool?
-    public var augmentsSyntaxTokens: Bool?
+	public var dynamicRegistration: Bool?
+	public var requests: Requests
+	public var tokenTypes: [String]
+	public var tokenModifiers: [String]
+	public var formats: [TokenFormat]
+	public var overlappingTokenSupport: Bool?
+	public var multilineTokenSupport: Bool?
+	public var serverCancelSupport: Bool?
+	public var augmentsSyntaxTokens: Bool?
 
-    public init(dynamicRegistration: Bool = false,
-                requests: SemanticTokensClientCapabilities.Requests = .init(range: true, delta: true),
-                tokenTypes: [String] = SemanticTokenTypes.allStrings,
-                tokenModifiers: [String] = SemanticTokenModifiers.allStrings,
-                formats: [TokenFormat] = [TokenFormat.relative],
-                overlappingTokenSupport: Bool = true,
-                multilineTokenSupport: Bool = true,
-                serverCancelSupport: Bool = false,
-                augmentsSyntaxTokens: Bool = true) {
-        self.dynamicRegistration = dynamicRegistration
-        self.requests = requests
-        self.tokenTypes = tokenTypes
-        self.tokenModifiers = tokenModifiers
-        self.formats = formats
-        self.overlappingTokenSupport = overlappingTokenSupport
-        self.multilineTokenSupport = multilineTokenSupport
-        self.serverCancelSupport = serverCancelSupport
-        self.augmentsSyntaxTokens = augmentsSyntaxTokens
-    }
+	public init(
+		dynamicRegistration: Bool = false,
+		requests: SemanticTokensClientCapabilities.Requests = .init(range: true, delta: true),
+		tokenTypes: [String] = SemanticTokenTypes.allStrings,
+		tokenModifiers: [String] = SemanticTokenModifiers.allStrings,
+		formats: [TokenFormat] = [TokenFormat.relative],
+		overlappingTokenSupport: Bool = true,
+		multilineTokenSupport: Bool = true,
+		serverCancelSupport: Bool = false,
+		augmentsSyntaxTokens: Bool = true
+	) {
+		self.dynamicRegistration = dynamicRegistration
+		self.requests = requests
+		self.tokenTypes = tokenTypes
+		self.tokenModifiers = tokenModifiers
+		self.formats = formats
+		self.overlappingTokenSupport = overlappingTokenSupport
+		self.multilineTokenSupport = multilineTokenSupport
+		self.serverCancelSupport = serverCancelSupport
+		self.augmentsSyntaxTokens = augmentsSyntaxTokens
+	}
 }
 
 public struct SemanticTokensLegend: Codable, Hashable, Sendable {
-    public var tokenTypes: [String]
-    public var tokenModifiers: [String]
+	public var tokenTypes: [String]
+	public var tokenModifiers: [String]
 }
 
 public enum SemanticTokenTypes: String, Codable, Hashable, CaseIterable, Sendable {
-    case namespace = "namespace"
-    case type = "type"
-    case `class` = "class"
-    case `enum` = "enum"
-    case interface = "interface"
-    case `struct` = "struct"
-    case typeParameter = "typeParameter"
-    case parameter = "parameter"
-    case variable = "variable"
-    case property = "property"
-    case enumMember = "enumMember"
-    case event = "event"
-    case function = "function"
-    case method = "method"
-    case macro = "macro"
-    case keyword = "keyword"
-    case modifier = "modifier"
-    case comment = "comment"
-    case string = "string"
-    case number = "number"
-    case regexp = "regexp"
-    case `operator` = "operator"
+	case namespace = "namespace"
+	case type = "type"
+	case `class` = "class"
+	case `enum` = "enum"
+	case interface = "interface"
+	case `struct` = "struct"
+	case typeParameter = "typeParameter"
+	case parameter = "parameter"
+	case variable = "variable"
+	case property = "property"
+	case enumMember = "enumMember"
+	case event = "event"
+	case function = "function"
+	case method = "method"
+	case macro = "macro"
+	case keyword = "keyword"
+	case modifier = "modifier"
+	case comment = "comment"
+	case string = "string"
+	case number = "number"
+	case regexp = "regexp"
+	case `operator` = "operator"
 
-    public static var allStrings: [String] {
-        return allCases.map({ $0.rawValue })
-    }
+	public static var allStrings: [String] {
+		return allCases.map({ $0.rawValue })
+	}
 }
 
 public enum SemanticTokenModifiers: String, Codable, Hashable, CaseIterable, Sendable {
-    case declaration = "declaration"
-    case definition = "definition"
-    case readonly = "readonly"
-    case `static` = "static"
-    case deprecated = "deprecated"
-    case abstract = "abstract"
-    case async = "async"
-    case modification = "modification"
-    case documentation = "documentation"
-    case defaultLibrary = "defaultLibrary"
+	case declaration = "declaration"
+	case definition = "definition"
+	case readonly = "readonly"
+	case `static` = "static"
+	case deprecated = "deprecated"
+	case abstract = "abstract"
+	case async = "async"
+	case modification = "modification"
+	case documentation = "documentation"
+	case defaultLibrary = "defaultLibrary"
 
-    public static var allStrings: [String] {
-        return allCases.map({ $0.rawValue })
-    }
+	public static var allStrings: [String] {
+		return allCases.map({ $0.rawValue })
+	}
 }
 
 public struct SemanticTokensParams: Codable, Hashable, Sendable {
-    public var workDoneToken: ProgressToken?
-    public var partialResultToken: ProgressToken?
-    public var textDocument: TextDocumentIdentifier
+	public var workDoneToken: ProgressToken?
+	public var partialResultToken: ProgressToken?
+	public var textDocument: TextDocumentIdentifier
 
-    public init(textDocument: TextDocumentIdentifier) {
-        self.textDocument = textDocument
-    }
+	public init(textDocument: TextDocumentIdentifier) {
+		self.textDocument = textDocument
+	}
 }
 
 public struct SemanticTokens: Codable, Hashable, Sendable {
-    public var resultId: String?
-    public var data: [UInt32]
+	public var resultId: String?
+	public var data: [UInt32]
 }
 
 public typealias SemanticTokensResponse = SemanticTokens?
 
 public struct SemanticTokensPartialResult: Codable, Hashable, Sendable {
-    public var data: [UInt32]
+	public var data: [UInt32]
 }
 
 public struct SemanticTokensDeltaParams: Codable, Hashable, Sendable {
-    public var workDoneToken: ProgressToken?
-    public var partialResultToken: ProgressToken?
-    public var textDocument: TextDocumentIdentifier
-    public var previousResultId: String
+	public var workDoneToken: ProgressToken?
+	public var partialResultToken: ProgressToken?
+	public var textDocument: TextDocumentIdentifier
+	public var previousResultId: String
 
-    public init(textDocument: TextDocumentIdentifier, previousResultId: String) {
-        self.textDocument = textDocument
-        self.previousResultId = previousResultId
-    }
+	public init(textDocument: TextDocumentIdentifier, previousResultId: String) {
+		self.textDocument = textDocument
+		self.previousResultId = previousResultId
+	}
 }
 
 public struct SemanticTokensEdit: Codable, Hashable, Sendable {
-    public var start: UInt
-    public var deleteCount: UInt
-    public var data: [UInt32]?
+	public var start: UInt
+	public var deleteCount: UInt
+	public var data: [UInt32]?
 }
 
 public struct SemanticTokensDelta: Codable, Hashable, Sendable {
-    public var resultId: String?
-    public var edits: [SemanticTokensEdit]
+	public var resultId: String?
+	public var edits: [SemanticTokensEdit]
 }
 
 public typealias SemanticTokensDeltaResponse = TwoTypeOption<SemanticTokens, SemanticTokensDelta>?
 
 public struct SemanticTokensRangeParams: Codable, Hashable, Sendable {
-    public var workDoneToken: ProgressToken?
-    public var partialResultToken: ProgressToken?
-    public var textDocument: TextDocumentIdentifier
-    public var range: LSPRange
+	public var workDoneToken: ProgressToken?
+	public var partialResultToken: ProgressToken?
+	public var textDocument: TextDocumentIdentifier
+	public var range: LSPRange
 
-    public init(textDocument: TextDocumentIdentifier, range: LSPRange) {
-        self.textDocument = textDocument
-        self.range = range
-    }
+	public init(textDocument: TextDocumentIdentifier, range: LSPRange) {
+		self.textDocument = textDocument
+		self.range = range
+	}
 }
 
-public extension TwoTypeOption where T == SemanticTokens, U == SemanticTokensDelta {
-	var resultId: String? {
+extension TwoTypeOption where T == SemanticTokens, U == SemanticTokensDelta {
+	public var resultId: String? {
 		switch self {
 		case .optionA(let token):
 			return token.resultId

--- a/Sources/LanguageServerProtocol/LanguageFeatures/SignatureHelp.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/SignatureHelp.swift
@@ -1,64 +1,75 @@
 import Foundation
 
 public struct SignatureHelpClientCapabilities: Codable, Hashable, Sendable {
-    public struct SignatureInformation: Codable, Hashable, Sendable {
-        public struct ParameterInformation: Codable, Hashable, Sendable {
-            public var labelOffsetSupport: Bool?
+	public struct SignatureInformation: Codable, Hashable, Sendable {
+		public struct ParameterInformation: Codable, Hashable, Sendable {
+			public var labelOffsetSupport: Bool?
 
-            public init(labelOffsetSupport: Bool? = nil) {
-                self.labelOffsetSupport = labelOffsetSupport
-            }
-        }
+			public init(labelOffsetSupport: Bool? = nil) {
+				self.labelOffsetSupport = labelOffsetSupport
+			}
+		}
 
-        public var documentationFormat: [MarkupKind]?
-        public var parameterInformation: ParameterInformation?
-        public var activeParameterSupport: Bool?
+		public var documentationFormat: [MarkupKind]?
+		public var parameterInformation: ParameterInformation?
+		public var activeParameterSupport: Bool?
 
-        public init(documentationFormat: [MarkupKind]? = nil, parameterInformation: ParameterInformation? = nil, activeParameterSupport: Bool? = nil) {
-            self.documentationFormat = documentationFormat
-            self.parameterInformation = parameterInformation
-            self.activeParameterSupport = activeParameterSupport
-        }
+		public init(
+			documentationFormat: [MarkupKind]? = nil,
+			parameterInformation: ParameterInformation? = nil, activeParameterSupport: Bool? = nil
+		) {
+			self.documentationFormat = documentationFormat
+			self.parameterInformation = parameterInformation
+			self.activeParameterSupport = activeParameterSupport
+		}
 
-        public init(documentationFormat: [MarkupKind]? = nil, labelOffsetSupport: Bool? = nil, activeParameterSupport: Bool? = nil) {
-            self.init(documentationFormat: documentationFormat,
-                      parameterInformation: ParameterInformation(labelOffsetSupport: labelOffsetSupport),
-                      activeParameterSupport: activeParameterSupport)
-        }
-    }
+		public init(
+			documentationFormat: [MarkupKind]? = nil, labelOffsetSupport: Bool? = nil,
+			activeParameterSupport: Bool? = nil
+		) {
+			self.init(
+				documentationFormat: documentationFormat,
+				parameterInformation: ParameterInformation(labelOffsetSupport: labelOffsetSupport),
+				activeParameterSupport: activeParameterSupport)
+		}
+	}
 
-    public var dynamicRegistration: Bool?
-    public var signatureInformation: SignatureInformation?
-    public var contextSupport: Bool?
+	public var dynamicRegistration: Bool?
+	public var signatureInformation: SignatureInformation?
+	public var contextSupport: Bool?
 
-    public init(dynamicRegistration: Bool?, signatureInformation: SignatureHelpClientCapabilities.SignatureInformation?, contextSupport: Bool?) {
-        self.dynamicRegistration = dynamicRegistration
-        self.signatureInformation = signatureInformation
-        self.contextSupport = contextSupport
-    }
+	public init(
+		dynamicRegistration: Bool?,
+		signatureInformation: SignatureHelpClientCapabilities.SignatureInformation?,
+		contextSupport: Bool?
+	) {
+		self.dynamicRegistration = dynamicRegistration
+		self.signatureInformation = signatureInformation
+		self.contextSupport = contextSupport
+	}
 }
 
 public struct ParameterInformation: Codable, Hashable, Sendable {
-    public var label: TwoTypeOption<String, [UInt]>
-    public var documentation: TwoTypeOption<String, MarkupContent>?
+	public var label: TwoTypeOption<String, [UInt]>
+	public var documentation: TwoTypeOption<String, MarkupContent>?
 }
 
 public struct SignatureInformation: Codable, Hashable, Sendable {
-    public var label: String
-    public var documentation: TwoTypeOption<String, MarkupContent>?
-    public var parameters: [ParameterInformation]?
-    public var activeParameter: UInt?
+	public var label: String
+	public var documentation: TwoTypeOption<String, MarkupContent>?
+	public var parameters: [ParameterInformation]?
+	public var activeParameter: UInt?
 }
 
 public struct SignatureHelp: Codable, Hashable, Sendable {
-    public let signatures: [SignatureInformation]
-    public let activeSignature: Int?
-    public let activeParameter: Int?
+	public let signatures: [SignatureInformation]
+	public let activeSignature: Int?
+	public let activeParameter: Int?
 }
 
 public struct SignatureHelpRegistrationOptions: Codable, Hashable, Sendable {
-    public let documentSelector: DocumentSelector?
-    public let triggerCharacters: [String]?
+	public let documentSelector: DocumentSelector?
+	public let triggerCharacters: [String]?
 }
 
 public typealias SignatureHelpResponse = SignatureHelp?

--- a/Sources/LanguageServerProtocol/LanguageServerProtocol.swift
+++ b/Sources/LanguageServerProtocol/LanguageServerProtocol.swift
@@ -4,132 +4,132 @@ typealias UnusedResult = String?
 typealias UnusedParam = String?
 
 public enum ClientNotification: Sendable, Hashable {
-    public enum Method: String, Hashable, Sendable {
-        case initialized
-        case exit
+	public enum Method: String, Hashable, Sendable {
+		case initialized
+		case exit
 		case windowWorkDoneProgressCancel = "window/workDoneProgress/cancel"
-        case workspaceDidChangeWatchedFiles = "workspace/didChangeWatchedFiles"
-        case workspaceDidChangeConfiguration = "workspace/didChangeConfiguration"
-        case workspaceDidChangeWorkspaceFolders = "workspace/didChangeWorkspaceFolders"
-        case workspaceDidCreateFiles = "workspace/didCreateFiles"
-        case workspaceDidRenameFiles = "workspace/didRenameFiles"
-        case workspaceDidDeleteFiles = "workspace/didDeleteFiles"
-        case textDocumentDidOpen = "textDocument/didOpen"
-        case textDocumentDidChange = "textDocument/didChange"
-        case textDocumentDidClose = "textDocument/didClose"
-        case textDocumentWillSave = "textDocument/willSave"
-        case textDocumentDidSave = "textDocument/didSave"
-        case protocolCancelRequest = "$/cancelRequest"
-        case protocolSetTrace = "$/setTrace"
-    }
+		case workspaceDidChangeWatchedFiles = "workspace/didChangeWatchedFiles"
+		case workspaceDidChangeConfiguration = "workspace/didChangeConfiguration"
+		case workspaceDidChangeWorkspaceFolders = "workspace/didChangeWorkspaceFolders"
+		case workspaceDidCreateFiles = "workspace/didCreateFiles"
+		case workspaceDidRenameFiles = "workspace/didRenameFiles"
+		case workspaceDidDeleteFiles = "workspace/didDeleteFiles"
+		case textDocumentDidOpen = "textDocument/didOpen"
+		case textDocumentDidChange = "textDocument/didChange"
+		case textDocumentDidClose = "textDocument/didClose"
+		case textDocumentWillSave = "textDocument/willSave"
+		case textDocumentDidSave = "textDocument/didSave"
+		case protocolCancelRequest = "$/cancelRequest"
+		case protocolSetTrace = "$/setTrace"
+	}
 
-    case initialized(InitializedParams)
-    case exit
-    case textDocumentDidChange(DidChangeTextDocumentParams)
-    case didOpenTextDocument(DidOpenTextDocumentParams)
-    case didChangeTextDocument(DidChangeTextDocumentParams)
-    case didCloseTextDocument(DidCloseTextDocumentParams)
-    case willSaveTextDocument(WillSaveTextDocumentParams)
-    case didSaveTextDocument(DidSaveTextDocumentParams)
-    case didChangeWatchedFiles(DidChangeWatchedFilesParams)
-    case protocolCancelRequest(CancelParams)
-    case protocolSetTrace(SetTraceParams)
+	case initialized(InitializedParams)
+	case exit
+	case textDocumentDidChange(DidChangeTextDocumentParams)
+	case didOpenTextDocument(DidOpenTextDocumentParams)
+	case didChangeTextDocument(DidChangeTextDocumentParams)
+	case didCloseTextDocument(DidCloseTextDocumentParams)
+	case willSaveTextDocument(WillSaveTextDocumentParams)
+	case didSaveTextDocument(DidSaveTextDocumentParams)
+	case didChangeWatchedFiles(DidChangeWatchedFilesParams)
+	case protocolCancelRequest(CancelParams)
+	case protocolSetTrace(SetTraceParams)
 	case windowWorkDoneProgressCancel(WorkDoneProgressCancelParams)
-    case workspaceDidChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams)
-    case workspaceDidChangeConfiguration(DidChangeConfigurationParams)
-    case workspaceDidCreateFiles(CreateFilesParams)
-    case workspaceDidRenameFiles(RenameFilesParams)
-    case workspaceDidDeleteFiles(DeleteFilesParams)
+	case workspaceDidChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams)
+	case workspaceDidChangeConfiguration(DidChangeConfigurationParams)
+	case workspaceDidCreateFiles(CreateFilesParams)
+	case workspaceDidRenameFiles(RenameFilesParams)
+	case workspaceDidDeleteFiles(DeleteFilesParams)
 
-    public var method: Method {
-        switch self {
-        case .initialized:
-            return .initialized
-        case .exit:
-            return .exit
-        case .textDocumentDidChange:
-            return .textDocumentDidChange
-        case .didOpenTextDocument:
-            return .textDocumentDidOpen
-        case .didCloseTextDocument:
-            return .textDocumentDidClose
-        case .willSaveTextDocument:
-            return .textDocumentWillSave
-        case .didChangeTextDocument:
-            return .textDocumentDidChange
-        case .didSaveTextDocument:
-            return .textDocumentDidSave
-        case .didChangeWatchedFiles:
-            return .workspaceDidChangeWatchedFiles
-        case .protocolCancelRequest:
-            return .protocolCancelRequest
-        case .protocolSetTrace:
-            return .protocolSetTrace
+	public var method: Method {
+		switch self {
+		case .initialized:
+			return .initialized
+		case .exit:
+			return .exit
+		case .textDocumentDidChange:
+			return .textDocumentDidChange
+		case .didOpenTextDocument:
+			return .textDocumentDidOpen
+		case .didCloseTextDocument:
+			return .textDocumentDidClose
+		case .willSaveTextDocument:
+			return .textDocumentWillSave
+		case .didChangeTextDocument:
+			return .textDocumentDidChange
+		case .didSaveTextDocument:
+			return .textDocumentDidSave
+		case .didChangeWatchedFiles:
+			return .workspaceDidChangeWatchedFiles
+		case .protocolCancelRequest:
+			return .protocolCancelRequest
+		case .protocolSetTrace:
+			return .protocolSetTrace
 		case .windowWorkDoneProgressCancel:
 			return .windowWorkDoneProgressCancel
-        case .workspaceDidChangeWorkspaceFolders:
-            return .workspaceDidChangeWorkspaceFolders
-        case .workspaceDidChangeConfiguration:
-            return .workspaceDidChangeConfiguration
-        case .workspaceDidCreateFiles:
-            return .workspaceDidCreateFiles
-        case .workspaceDidRenameFiles:
-            return .workspaceDidRenameFiles
-        case .workspaceDidDeleteFiles:
-            return .workspaceDidDeleteFiles
-        }
-    }
+		case .workspaceDidChangeWorkspaceFolders:
+			return .workspaceDidChangeWorkspaceFolders
+		case .workspaceDidChangeConfiguration:
+			return .workspaceDidChangeConfiguration
+		case .workspaceDidCreateFiles:
+			return .workspaceDidCreateFiles
+		case .workspaceDidRenameFiles:
+			return .workspaceDidRenameFiles
+		case .workspaceDidDeleteFiles:
+			return .workspaceDidDeleteFiles
+		}
+	}
 }
 
 public enum ClientRequest: Sendable, Hashable {
 	public enum Method: String, Hashable, Sendable {
-        case initialize
-        case shutdown
-        case workspaceExecuteCommand = "workspace/executeCommand"
-        case workspaceWillCreateFiles = "workspace/willCreateFiles"
-        case workspaceWillRenameFiles = "workspace/willRenameFiles"
-        case workspaceWillDeleteFiles = "workspace/willDeleteFiles"
-        case workspaceSymbol = "workspace/symbol"
-        case workspaceSymbolResolve = "workspaceSymbol/resolve"
-        case textDocumentWillSaveWaitUntil = "textDocument/willSaveWaitUntil"
-        case textDocumentCompletion = "textDocument/completion"
-        case completionItemResolve = "completionItem/resolve"
-        case textDocumentHover = "textDocument/hover"
-        case textDocumentSignatureHelp = "textDocument/signatureHelp"
-        case textDocumentDeclaration = "textDocument/declaration"
-        case textDocumentDefinition = "textDocument/definition"
-        case textDocumentTypeDefinition = "textDocument/typeDefinition"
-        case textDocumentImplementation = "textDocument/implementation"
-        case textDocumentReferences = "textDocument/references"
-        case textDocumentDocumentHighlight = "textDocument/documentHighlight"
-        case textDocumentDocumentSymbol = "textDocument/documentSymbol"
-        case textDocumentCodeAction = "textDocument/codeAction"
+		case initialize
+		case shutdown
+		case workspaceExecuteCommand = "workspace/executeCommand"
+		case workspaceWillCreateFiles = "workspace/willCreateFiles"
+		case workspaceWillRenameFiles = "workspace/willRenameFiles"
+		case workspaceWillDeleteFiles = "workspace/willDeleteFiles"
+		case workspaceSymbol = "workspace/symbol"
+		case workspaceSymbolResolve = "workspaceSymbol/resolve"
+		case textDocumentWillSaveWaitUntil = "textDocument/willSaveWaitUntil"
+		case textDocumentCompletion = "textDocument/completion"
+		case completionItemResolve = "completionItem/resolve"
+		case textDocumentHover = "textDocument/hover"
+		case textDocumentSignatureHelp = "textDocument/signatureHelp"
+		case textDocumentDeclaration = "textDocument/declaration"
+		case textDocumentDefinition = "textDocument/definition"
+		case textDocumentTypeDefinition = "textDocument/typeDefinition"
+		case textDocumentImplementation = "textDocument/implementation"
+		case textDocumentReferences = "textDocument/references"
+		case textDocumentDocumentHighlight = "textDocument/documentHighlight"
+		case textDocumentDocumentSymbol = "textDocument/documentSymbol"
+		case textDocumentCodeAction = "textDocument/codeAction"
 		case codeActionResolve = "codeAction/resolve"
-        case codeLensResolve = "codeLens/resolve"
-        case textDocumentCodeLens = "textDocument/codeLens"
+		case codeLensResolve = "codeLens/resolve"
+		case textDocumentCodeLens = "textDocument/codeLens"
 		case textDocumentDiagnostic = "textDocument/diagnostic"
-        case textDocumentDocumentLink = "textDocument/documentLink"
-        case documentLinkResolve = "documentLink/resolve"
-        case textDocumentDocumentColor = "textDocument/documentColor"
-        case textDocumentColorPresentation = "textDocument/colorPresentation"
-        case textDocumentFormatting = "textDocument/formatting"
-        case textDocumentRangeFormatting = "textDocument/rangeFormatting"
-        case textDocumentOnTypeFormatting = "textDocument/onTypeFormatting"
-        case textDocumentRename = "textDocument/rename"
-        case textDocumentPrepareRename = "textDocument/prepareRename"
+		case textDocumentDocumentLink = "textDocument/documentLink"
+		case documentLinkResolve = "documentLink/resolve"
+		case textDocumentDocumentColor = "textDocument/documentColor"
+		case textDocumentColorPresentation = "textDocument/colorPresentation"
+		case textDocumentFormatting = "textDocument/formatting"
+		case textDocumentRangeFormatting = "textDocument/rangeFormatting"
+		case textDocumentOnTypeFormatting = "textDocument/onTypeFormatting"
+		case textDocumentRename = "textDocument/rename"
+		case textDocumentPrepareRename = "textDocument/prepareRename"
 		case textDocumentPrepareCallHierarchy = "textDocument/prepareCallHierarchy"
-        case textDocumentFoldingRange = "textDocument/foldingRange"
-        case textDocumentSelectionRange = "textDocument/selectionRange"
-        case textDocumentLinkedEditingRange = "textDocument/linkedEditingRange"
-        case textDocumentSemanticTokens = "textDocument/semanticTokens"
-        case textDocumentSemanticTokensRange = "textDocument/semanticTokens/range"
-        case textDocumentSemanticTokensFull = "textDocument/semanticTokens/full"
-        case textDocumentSemanticTokensFullDelta = "textDocument/semanticTokens/full/delta"
-        case textDocumentMoniker = "textDocument/moniker"
+		case textDocumentFoldingRange = "textDocument/foldingRange"
+		case textDocumentSelectionRange = "textDocument/selectionRange"
+		case textDocumentLinkedEditingRange = "textDocument/linkedEditingRange"
+		case textDocumentSemanticTokens = "textDocument/semanticTokens"
+		case textDocumentSemanticTokensRange = "textDocument/semanticTokens/range"
+		case textDocumentSemanticTokensFull = "textDocument/semanticTokens/full"
+		case textDocumentSemanticTokensFullDelta = "textDocument/semanticTokens/full/delta"
+		case textDocumentMoniker = "textDocument/moniker"
 		case callHierarchyIncomingCalls = "callHierarchy/incomingCalls"
 		case callHierarchyOutgoingCalls = "callHierarchy/outgoingCalls"
-        case custom
-    }
+		case custom
+	}
 
 	case initialize(InitializeParams)
 	case shutdown
@@ -175,192 +175,195 @@ public enum ClientRequest: Sendable, Hashable {
 	case callHierarchyOutgoingCalls(CallHierarchyOutgoingCallsParams)
 	case custom(String, LSPAny)
 
-    public var method: Method {
-        switch self {
-        case .initialize:
-            return .initialize
-        case .shutdown:
-            return .shutdown
-        case .workspaceExecuteCommand:
-            return .workspaceExecuteCommand
-        case .workspaceWillCreateFiles:
-            return .workspaceWillCreateFiles
-        case .workspaceWillRenameFiles:
-            return .workspaceWillRenameFiles
-        case .workspaceWillDeleteFiles:
-            return .workspaceWillDeleteFiles
-        case .workspaceSymbol:
-            return .workspaceSymbol
-        case .workspaceSymbolResolve:
-            return .workspaceSymbolResolve
-        case .willSaveWaitUntilTextDocument:
-            return .textDocumentWillSaveWaitUntil
-        case .completion:
-            return .textDocumentCompletion
-        case .completionItemResolve:
-            return .completionItemResolve
-        case .hover:
-            return .textDocumentHover
-        case .signatureHelp:
-            return .textDocumentSignatureHelp
-        case .declaration:
-            return .textDocumentDeclaration
-        case .definition:
-            return .textDocumentDefinition
-        case .typeDefinition:
-            return .textDocumentTypeDefinition
-        case .implementation:
-            return .textDocumentImplementation
-        case .documentHighlight:
-            return .textDocumentDocumentHighlight
-        case .documentSymbol:
-            return .textDocumentDocumentSymbol
-        case .codeAction:
-            return .textDocumentCodeAction
+	public var method: Method {
+		switch self {
+		case .initialize:
+			return .initialize
+		case .shutdown:
+			return .shutdown
+		case .workspaceExecuteCommand:
+			return .workspaceExecuteCommand
+		case .workspaceWillCreateFiles:
+			return .workspaceWillCreateFiles
+		case .workspaceWillRenameFiles:
+			return .workspaceWillRenameFiles
+		case .workspaceWillDeleteFiles:
+			return .workspaceWillDeleteFiles
+		case .workspaceSymbol:
+			return .workspaceSymbol
+		case .workspaceSymbolResolve:
+			return .workspaceSymbolResolve
+		case .willSaveWaitUntilTextDocument:
+			return .textDocumentWillSaveWaitUntil
+		case .completion:
+			return .textDocumentCompletion
+		case .completionItemResolve:
+			return .completionItemResolve
+		case .hover:
+			return .textDocumentHover
+		case .signatureHelp:
+			return .textDocumentSignatureHelp
+		case .declaration:
+			return .textDocumentDeclaration
+		case .definition:
+			return .textDocumentDefinition
+		case .typeDefinition:
+			return .textDocumentTypeDefinition
+		case .implementation:
+			return .textDocumentImplementation
+		case .documentHighlight:
+			return .textDocumentDocumentHighlight
+		case .documentSymbol:
+			return .textDocumentDocumentSymbol
+		case .codeAction:
+			return .textDocumentCodeAction
 		case .codeActionResolve:
 			return .codeActionResolve
-        case .codeLens:
-            return .textDocumentCodeLens
-        case .codeLensResolve:
-            return .codeLensResolve
-        case .selectionRange:
-            return .textDocumentSelectionRange
+		case .codeLens:
+			return .textDocumentCodeLens
+		case .codeLensResolve:
+			return .codeLensResolve
+		case .selectionRange:
+			return .textDocumentSelectionRange
 		case .prepareCallHierarchy:
 			return .textDocumentPrepareCallHierarchy
-        case .prepareRename:
-            return .textDocumentPrepareRename
-        case .rename:
-            return .textDocumentRename
-        case .documentLink:
-            return .textDocumentDocumentLink
-        case .documentLinkResolve:
-            return .documentLinkResolve
-        case .documentColor:
-            return .textDocumentDocumentColor
+		case .prepareRename:
+			return .textDocumentPrepareRename
+		case .rename:
+			return .textDocumentRename
+		case .documentLink:
+			return .textDocumentDocumentLink
+		case .documentLinkResolve:
+			return .documentLinkResolve
+		case .documentColor:
+			return .textDocumentDocumentColor
 		case .diagnostics:
 			return .textDocumentDiagnostic
-        case .colorPresentation:
-            return .textDocumentColorPresentation
-        case .formatting:
-            return .textDocumentFormatting
-        case .rangeFormatting:
-            return .textDocumentRangeFormatting
-        case .onTypeFormatting:
-            return .textDocumentOnTypeFormatting
-        case .references:
-            return .textDocumentReferences
-        case .foldingRange:
-            return .textDocumentFoldingRange
-        case .semanticTokensFull:
-            return .textDocumentSemanticTokensFull
-        case .semanticTokensFullDelta:
-            return .textDocumentSemanticTokensFullDelta
-        case .semanticTokensRange:
-            return .textDocumentSemanticTokensRange
+		case .colorPresentation:
+			return .textDocumentColorPresentation
+		case .formatting:
+			return .textDocumentFormatting
+		case .rangeFormatting:
+			return .textDocumentRangeFormatting
+		case .onTypeFormatting:
+			return .textDocumentOnTypeFormatting
+		case .references:
+			return .textDocumentReferences
+		case .foldingRange:
+			return .textDocumentFoldingRange
+		case .semanticTokensFull:
+			return .textDocumentSemanticTokensFull
+		case .semanticTokensFullDelta:
+			return .textDocumentSemanticTokensFullDelta
+		case .semanticTokensRange:
+			return .textDocumentSemanticTokensRange
 		case .callHierarchyIncomingCalls:
 			return .callHierarchyIncomingCalls
 		case .callHierarchyOutgoingCalls:
 			return .callHierarchyOutgoingCalls
-        case .custom:
-            return .custom
-        }
-    }
+		case .custom:
+			return .custom
+		}
+	}
 }
 
 public enum ServerNotification: Sendable, Hashable {
-    public enum Method: String, Hashable, Sendable {
-        case windowLogMessage = "window/logMessage"
-        case windowShowMessage = "window/showMessage"
-        case textDocumentPublishDiagnostics = "textDocument/publishDiagnostics"
-        case telemetryEvent = "telemetry/event"
-        case protocolCancelRequest = "$/cancelRequest"
-        case protocolProgress = "$/progress"
-        case protocolLogTrace = "$/logTrace"
-    }
+	public enum Method: String, Hashable, Sendable {
+		case windowLogMessage = "window/logMessage"
+		case windowShowMessage = "window/showMessage"
+		case textDocumentPublishDiagnostics = "textDocument/publishDiagnostics"
+		case telemetryEvent = "telemetry/event"
+		case protocolCancelRequest = "$/cancelRequest"
+		case protocolProgress = "$/progress"
+		case protocolLogTrace = "$/logTrace"
+	}
 
-    case windowLogMessage(LogMessageParams)
-    case windowShowMessage(ShowMessageParams)
-    case textDocumentPublishDiagnostics(PublishDiagnosticsParams)
-    case telemetryEvent(LSPAny)
-    case protocolCancelRequest(CancelParams)
-    case protocolProgress(ProgressParams)
-    case protocolLogTrace(LogTraceParams)
+	case windowLogMessage(LogMessageParams)
+	case windowShowMessage(ShowMessageParams)
+	case textDocumentPublishDiagnostics(PublishDiagnosticsParams)
+	case telemetryEvent(LSPAny)
+	case protocolCancelRequest(CancelParams)
+	case protocolProgress(ProgressParams)
+	case protocolLogTrace(LogTraceParams)
 
-    public var method: Method {
-        switch self {
-        case .windowLogMessage:
-            return .windowLogMessage
-        case .windowShowMessage:
-            return .windowShowMessage
-        case .textDocumentPublishDiagnostics:
-            return .textDocumentPublishDiagnostics
-        case .telemetryEvent:
-            return .telemetryEvent
-        case .protocolCancelRequest:
-            return .protocolCancelRequest
-        case .protocolProgress:
-            return .protocolProgress
-        case .protocolLogTrace:
-            return .protocolLogTrace
-        }
-    }
+	public var method: Method {
+		switch self {
+		case .windowLogMessage:
+			return .windowLogMessage
+		case .windowShowMessage:
+			return .windowShowMessage
+		case .textDocumentPublishDiagnostics:
+			return .textDocumentPublishDiagnostics
+		case .telemetryEvent:
+			return .telemetryEvent
+		case .protocolCancelRequest:
+			return .protocolCancelRequest
+		case .protocolProgress:
+			return .protocolProgress
+		case .protocolLogTrace:
+			return .protocolLogTrace
+		}
+	}
 }
 
 public enum ServerRequest: Sendable {
-	public typealias Handler<T: Sendable & Encodable> = @Sendable (Result<T, AnyJSONRPCResponseError>) async -> Void
+	public typealias Handler<T: Sendable & Encodable> = @Sendable (
+		Result<T, AnyJSONRPCResponseError>
+	) async -> Void
 	public typealias ErrorOnlyHandler = @Sendable (AnyJSONRPCResponseError?) async -> Void
 
-    public enum Method: String {
-        case workspaceConfiguration = "workspace/configuration"
-        case workspaceFolders = "workspace/workspaceFolders"
-        case workspaceApplyEdit = "workspace/applyEdit"
-        case clientRegisterCapability = "client/registerCapability"
-        case clientUnregisterCapability = "client/unregisterCapability"
-        case workspaceCodeLensRefresh = "workspace/codeLens/refresh"
-        case workspaceSemanticTokenRefresh = "workspace/semanticTokens/refresh"
-        case windowShowMessageRequest = "window/showMessageRequest"
-        case windowShowDocument = "window/showDocument"
-        case windowWorkDoneProgressCreate = "window/workDoneProgress/create"
-    }
+	public enum Method: String {
+		case workspaceConfiguration = "workspace/configuration"
+		case workspaceFolders = "workspace/workspaceFolders"
+		case workspaceApplyEdit = "workspace/applyEdit"
+		case clientRegisterCapability = "client/registerCapability"
+		case clientUnregisterCapability = "client/unregisterCapability"
+		case workspaceCodeLensRefresh = "workspace/codeLens/refresh"
+		case workspaceSemanticTokenRefresh = "workspace/semanticTokens/refresh"
+		case windowShowMessageRequest = "window/showMessageRequest"
+		case windowShowDocument = "window/showDocument"
+		case windowWorkDoneProgressCreate = "window/workDoneProgress/create"
+	}
 
-    case workspaceConfiguration(ConfigurationParams, Handler<[LSPAny]>)
-    case workspaceFolders(Handler<WorkspaceFoldersResponse>)
-    case workspaceApplyEdit(ApplyWorkspaceEditParams, Handler<ApplyWorkspaceEditResult>)
-    case clientRegisterCapability(RegistrationParams, ErrorOnlyHandler)
-    case clientUnregisterCapability(UnregistrationParams, ErrorOnlyHandler)
-    case workspaceCodeLensRefresh(ErrorOnlyHandler)
-    case workspaceSemanticTokenRefresh(ErrorOnlyHandler)
-    case windowShowMessageRequest(ShowMessageRequestParams, Handler<ShowMessageRequestResponse>)
-    case windowShowDocument(ShowDocumentParams, Handler<ShowDocumentResult>)
+	case workspaceConfiguration(ConfigurationParams, Handler<[LSPAny]>)
+	case workspaceFolders(Handler<WorkspaceFoldersResponse>)
+	case workspaceApplyEdit(ApplyWorkspaceEditParams, Handler<ApplyWorkspaceEditResult>)
+	case clientRegisterCapability(RegistrationParams, ErrorOnlyHandler)
+	case clientUnregisterCapability(UnregistrationParams, ErrorOnlyHandler)
+	case workspaceCodeLensRefresh(ErrorOnlyHandler)
+	case workspaceSemanticTokenRefresh(ErrorOnlyHandler)
+	case windowShowMessageRequest(ShowMessageRequestParams, Handler<ShowMessageRequestResponse>)
+	case windowShowDocument(ShowDocumentParams, Handler<ShowDocumentResult>)
 	case windowWorkDoneProgressCreate(WorkDoneProgressCreateParams, ErrorOnlyHandler)
 
-    public var method: Method {
-        switch self {
-        case .workspaceConfiguration:
-            return .workspaceConfiguration
-        case .workspaceFolders:
-            return .workspaceFolders
-        case .workspaceApplyEdit:
-            return .workspaceApplyEdit
-        case .clientRegisterCapability:
-            return .clientRegisterCapability
-        case .clientUnregisterCapability:
-            return .clientUnregisterCapability
-        case .workspaceCodeLensRefresh:
-            return .workspaceCodeLensRefresh
-        case .workspaceSemanticTokenRefresh:
-            return .workspaceSemanticTokenRefresh
-        case .windowShowMessageRequest:
-            return .windowShowMessageRequest
-        case .windowShowDocument:
-            return .windowShowDocument
-        case .windowWorkDoneProgressCreate:
-            return .windowWorkDoneProgressCreate
-        }
-    }
+	public var method: Method {
+		switch self {
+		case .workspaceConfiguration:
+			return .workspaceConfiguration
+		case .workspaceFolders:
+			return .workspaceFolders
+		case .workspaceApplyEdit:
+			return .workspaceApplyEdit
+		case .clientRegisterCapability:
+			return .clientRegisterCapability
+		case .clientUnregisterCapability:
+			return .clientUnregisterCapability
+		case .workspaceCodeLensRefresh:
+			return .workspaceCodeLensRefresh
+		case .workspaceSemanticTokenRefresh:
+			return .workspaceSemanticTokenRefresh
+		case .windowShowMessageRequest:
+			return .windowShowMessageRequest
+		case .windowShowDocument:
+			return .windowShowDocument
+		case .windowWorkDoneProgressCreate:
+			return .windowWorkDoneProgressCreate
+		}
+	}
 
 	public func relyWithError(_ error: Error) async {
-		let protocolError = AnyJSONRPCResponseError(code: JSONRPCErrors.internalError, message: "unsupported", data: nil)
+		let protocolError = AnyJSONRPCResponseError(
+			code: JSONRPCErrors.internalError, message: "unsupported", data: nil)
 
 		switch self {
 		case let .workspaceConfiguration(_, handler):
@@ -388,29 +391,29 @@ public enum ServerRequest: Sendable {
 }
 
 public enum ServerRegistration {
-    public enum Method: String {
-        case workspaceDidChangeWatchedFiles = "workspace/didChangeWatchedFiles"
-        case workspaceDidChangeConfiguration = "workspace/didChangeConfiguration"
-        case workspaceDidChangeWorkspaceFolders = "workspace/didChangeWorkspaceFolders"
+	public enum Method: String {
+		case workspaceDidChangeWatchedFiles = "workspace/didChangeWatchedFiles"
+		case workspaceDidChangeConfiguration = "workspace/didChangeConfiguration"
+		case workspaceDidChangeWorkspaceFolders = "workspace/didChangeWorkspaceFolders"
 
-        case textDocumentSemanticTokens = "textDocument/semanticTokens"
-    }
+		case textDocumentSemanticTokens = "textDocument/semanticTokens"
+	}
 
-    case workspaceDidChangeWatchedFiles(DidChangeWatchedFilesRegistrationOptions)
-    case textDocumentSemanticTokens(SemanticTokensRegistrationOptions)
-    case workspaceDidChangeConfiguration
-    case workspaceDidChangeWorkspaceFolders
+	case workspaceDidChangeWatchedFiles(DidChangeWatchedFilesRegistrationOptions)
+	case textDocumentSemanticTokens(SemanticTokensRegistrationOptions)
+	case workspaceDidChangeConfiguration
+	case workspaceDidChangeWorkspaceFolders
 
-    public var method: Method {
-        switch self {
-        case .workspaceDidChangeWatchedFiles:
-            return .workspaceDidChangeWatchedFiles
-        case .textDocumentSemanticTokens:
-            return .textDocumentSemanticTokens
-        case .workspaceDidChangeConfiguration:
-            return .workspaceDidChangeConfiguration
-        case .workspaceDidChangeWorkspaceFolders:
-            return .workspaceDidChangeWorkspaceFolders
-        }
-    }
+	public var method: Method {
+		switch self {
+		case .workspaceDidChangeWatchedFiles:
+			return .workspaceDidChangeWatchedFiles
+		case .textDocumentSemanticTokens:
+			return .textDocumentSemanticTokens
+		case .workspaceDidChangeConfiguration:
+			return .workspaceDidChangeConfiguration
+		case .workspaceDidChangeWorkspaceFolders:
+			return .workspaceDidChangeWorkspaceFolders
+		}
+	}
 }

--- a/Sources/LanguageServerProtocol/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ServerCapabilities.swift
@@ -1,60 +1,67 @@
 import Foundation
 
-public struct StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var textDocument: TextDocumentIdentifier
-    public var position: Position
-    public var documentSelector: DocumentSelector?
-    public var id: String?
+public struct StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions: Codable, Hashable,
+	Sendable
+{
+	public var workDoneProgress: Bool?
+	public var textDocument: TextDocumentIdentifier
+	public var position: Position
+	public var documentSelector: DocumentSelector?
+	public var id: String?
 }
 
-public struct PartialResultsWorkDoneProgressTextDocumentRegistrationOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var textDocument: TextDocumentIdentifier
-    public var position: Position
-    public var documentSelector: DocumentSelector?
-    public var partialResultToken: ProgressToken?
+public struct PartialResultsWorkDoneProgressTextDocumentRegistrationOptions: Codable, Hashable,
+	Sendable
+{
+	public var workDoneProgress: Bool?
+	public var textDocument: TextDocumentIdentifier
+	public var position: Position
+	public var documentSelector: DocumentSelector?
+	public var partialResultToken: ProgressToken?
 }
 
 public struct WorkDoneProgressOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
+	public var workDoneProgress: Bool?
 }
 
 public struct SaveOptions: Codable, Hashable, Sendable {
-    public let includeText: Bool?
+	public let includeText: Bool?
 }
 
 public enum TextDocumentSyncKind: Int, Codable, Hashable, Sendable {
-    case none = 0
-    case full = 1
-    case incremental = 2
+	case none = 0
+	case full = 1
+	case incremental = 2
 }
 
 public struct TextDocumentSyncOptions: Codable, Hashable, Sendable {
-    public var openClose: Bool?
-    public var change: TextDocumentSyncKind?
-    public var willSave: Bool?
-    public var willSaveWaitUntil: Bool?
-    public var save: TwoTypeOption<Bool, SaveOptions>?
+	public var openClose: Bool?
+	public var change: TextDocumentSyncKind?
+	public var willSave: Bool?
+	public var willSaveWaitUntil: Bool?
+	public var save: TwoTypeOption<Bool, SaveOptions>?
 
-    public var effectiveSave: SaveOptions? {
-        switch save {
-        case nil:
-            return nil
-        case .optionA(let value):
-            return value ? SaveOptions(includeText: false) : nil
-        case .optionB(let options):
-            return options
-        }
-    }
+	public var effectiveSave: SaveOptions? {
+		switch save {
+		case nil:
+			return nil
+		case .optionA(let value):
+			return value ? SaveOptions(includeText: false) : nil
+		case .optionB(let options):
+			return options
+		}
+	}
 
-	public init(openClose: Bool? = nil, change: TextDocumentSyncKind? = nil, willSave: Bool? = nil, willSaveWaitUntil: Bool? = nil, save: TwoTypeOption<Bool, SaveOptions>? = nil) {
-        self.openClose = openClose
-        self.change = change
-        self.willSave = willSave
-        self.willSaveWaitUntil = willSaveWaitUntil
-        self.save = save
-    }
+	public init(
+		openClose: Bool? = nil, change: TextDocumentSyncKind? = nil, willSave: Bool? = nil,
+		willSaveWaitUntil: Bool? = nil, save: TwoTypeOption<Bool, SaveOptions>? = nil
+	) {
+		self.openClose = openClose
+		self.change = change
+		self.willSave = willSave
+		self.willSaveWaitUntil = willSaveWaitUntil
+		self.save = save
+	}
 
 }
 
@@ -91,60 +98,70 @@ public struct CompletionOptions: Codable, Hashable, Sendable {
 public typealias HoverOptions = WorkDoneProgressOptions
 
 public struct SignatureHelpOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var triggerCharacters: [String]?
-    public var retriggerCharacters: [String]?
+	public var workDoneProgress: Bool?
+	public var triggerCharacters: [String]?
+	public var retriggerCharacters: [String]?
 }
 
 public typealias DeclarationOptions = WorkDoneProgressOptions
 
-public typealias DeclarationRegistrationOptions = StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
+public typealias DeclarationRegistrationOptions =
+	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
 public typealias DefinitionOptions = WorkDoneProgressOptions
 
 public typealias TypeDefinitionOptions = WorkDoneProgressOptions
 
-public typealias TypeDefinitionRegistrationOptions = PartialResultsWorkDoneProgressTextDocumentRegistrationOptions
+public typealias TypeDefinitionRegistrationOptions =
+	PartialResultsWorkDoneProgressTextDocumentRegistrationOptions
 
 public typealias ImplementationOptions = WorkDoneProgressOptions
 
-public typealias ImplementationRegistrationOptions = StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
+public typealias ImplementationRegistrationOptions =
+	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
 public typealias ReferenceOptions = WorkDoneProgressOptions
 
 public struct DocumentSymbolOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var label: String?
+	public var workDoneProgress: Bool?
+	public var label: String?
 }
 
 public typealias DocumentColorOptions = WorkDoneProgressOptions
 
-public typealias DocumentColorRegistrationOptions = StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
+public typealias DocumentColorRegistrationOptions =
+	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
 public typealias DocumentFormattingOptions = WorkDoneProgressOptions
 
 public typealias DocumentRangeFormattingOptions = WorkDoneProgressOptions
 
 public struct DocumentOnTypeFormattingOptions: Codable, Hashable, Sendable {
-    public var firstTriggerCharacter: String
-    public var moreTriggerCharacter: [String]?
+	public var firstTriggerCharacter: String
+	public var moreTriggerCharacter: [String]?
 }
 
 public typealias FoldingRangeOptions = WorkDoneProgressOptions
 
-public typealias FoldingRangeRegistrationOptions = StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
+public typealias FoldingRangeRegistrationOptions =
+	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
 public typealias LinkedEditingRangeOptions = WorkDoneProgressOptions
 
-public typealias LinkedEditingRangeRegistrationOptions = StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
+public typealias LinkedEditingRangeRegistrationOptions =
+	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
 public struct SemanticTokensOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var legend: SemanticTokensLegend
-    public var range: SemanticTokensClientCapabilities.Requests.RangeOption?
-    public var full: SemanticTokensClientCapabilities.Requests.FullOption?
+	public var workDoneProgress: Bool?
+	public var legend: SemanticTokensLegend
+	public var range: SemanticTokensClientCapabilities.Requests.RangeOption?
+	public var full: SemanticTokensClientCapabilities.Requests.FullOption?
 
-	public init(workDoneProgress: Bool? = nil, legend: SemanticTokensLegend, range: SemanticTokensClientCapabilities.Requests.RangeOption? = nil, full: SemanticTokensClientCapabilities.Requests.FullOption? = nil) {
+	public init(
+		workDoneProgress: Bool? = nil, legend: SemanticTokensLegend,
+		range: SemanticTokensClientCapabilities.Requests.RangeOption? = nil,
+		full: SemanticTokensClientCapabilities.Requests.FullOption? = nil
+	) {
 		self.workDoneProgress = workDoneProgress
 		self.legend = legend
 		self.range = range
@@ -154,14 +171,19 @@ public struct SemanticTokensOptions: Codable, Hashable, Sendable {
 }
 
 public struct SemanticTokensRegistrationOptions: Codable, Hashable, Sendable {
-    public var documentSelector: DocumentSelector?
-    public var workDoneProgress: Bool?
-    public var legend: SemanticTokensLegend
-    public var range: SemanticTokensClientCapabilities.Requests.RangeOption?
-    public var full: SemanticTokensClientCapabilities.Requests.FullOption?
-    public var id: String?
+	public var documentSelector: DocumentSelector?
+	public var workDoneProgress: Bool?
+	public var legend: SemanticTokensLegend
+	public var range: SemanticTokensClientCapabilities.Requests.RangeOption?
+	public var full: SemanticTokensClientCapabilities.Requests.FullOption?
+	public var id: String?
 
-	public init(documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil, legend: SemanticTokensLegend, range: SemanticTokensClientCapabilities.Requests.RangeOption? = nil, full: SemanticTokensClientCapabilities.Requests.FullOption? = nil, id: String? = nil) {
+	public init(
+		documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil,
+		legend: SemanticTokensLegend,
+		range: SemanticTokensClientCapabilities.Requests.RangeOption? = nil,
+		full: SemanticTokensClientCapabilities.Requests.FullOption? = nil, id: String? = nil
+	) {
 		self.documentSelector = documentSelector
 		self.workDoneProgress = workDoneProgress
 		self.legend = legend
@@ -173,29 +195,32 @@ public struct SemanticTokensRegistrationOptions: Codable, Hashable, Sendable {
 
 public typealias MonikerOptions = WorkDoneProgressOptions
 
-public typealias MonikerRegistrationOptions = PartialResultsWorkDoneProgressTextDocumentRegistrationOptions
+public typealias MonikerRegistrationOptions =
+	PartialResultsWorkDoneProgressTextDocumentRegistrationOptions
 
 public struct WorkspaceFoldersServerCapabilities: Codable, Hashable, Sendable {
-    public var supported: Bool?
-    public var changeNotifications: TwoTypeOption<String, Bool>?
+	public var supported: Bool?
+	public var changeNotifications: TwoTypeOption<String, Bool>?
 }
 
 public struct ServerCapabilities: Codable, Hashable, Sendable {
-    public struct Workspace: Codable, Hashable, Sendable {
-        public struct FileOperations: Codable, Hashable, Sendable {
-            public var didCreate: FileOperationRegistrationOptions?
-            public var willCreate: FileOperationRegistrationOptions?
-            public var didRename: FileOperationRegistrationOptions?
-            public var willRename: FileOperationRegistrationOptions?
-            public var didDelete: FileOperationRegistrationOptions?
-            public var willDelete: FileOperationRegistrationOptions?
+	public struct Workspace: Codable, Hashable, Sendable {
+		public struct FileOperations: Codable, Hashable, Sendable {
+			public var didCreate: FileOperationRegistrationOptions?
+			public var willCreate: FileOperationRegistrationOptions?
+			public var didRename: FileOperationRegistrationOptions?
+			public var willRename: FileOperationRegistrationOptions?
+			public var didDelete: FileOperationRegistrationOptions?
+			public var willDelete: FileOperationRegistrationOptions?
 
-			public init(didCreate: FileOperationRegistrationOptions? = nil,
-						willCreate: FileOperationRegistrationOptions? = nil,
-						didRename: FileOperationRegistrationOptions? = nil,
-						willRename: FileOperationRegistrationOptions? = nil,
-						didDelete: FileOperationRegistrationOptions? = nil,
-						willDelete: FileOperationRegistrationOptions? = nil) {
+			public init(
+				didCreate: FileOperationRegistrationOptions? = nil,
+				willCreate: FileOperationRegistrationOptions? = nil,
+				didRename: FileOperationRegistrationOptions? = nil,
+				willRename: FileOperationRegistrationOptions? = nil,
+				didDelete: FileOperationRegistrationOptions? = nil,
+				willDelete: FileOperationRegistrationOptions? = nil
+			) {
 				self.didCreate = didCreate
 				self.willCreate = willCreate
 				self.didRename = didRename
@@ -203,48 +228,59 @@ public struct ServerCapabilities: Codable, Hashable, Sendable {
 				self.didDelete = didDelete
 				self.willDelete = willDelete
 			}
-        }
+		}
 
-        public var workspaceFolders: WorkspaceFoldersServerCapabilities?
-        public var fileOperations: FileOperations?
+		public var workspaceFolders: WorkspaceFoldersServerCapabilities?
+		public var fileOperations: FileOperations?
 
-		public init(workspaceFolders: WorkspaceFoldersServerCapabilities? = nil,
-					fileOperations: FileOperations? = nil) {
+		public init(
+			workspaceFolders: WorkspaceFoldersServerCapabilities? = nil,
+			fileOperations: FileOperations? = nil
+		) {
 			self.workspaceFolders = workspaceFolders
 			self.fileOperations = fileOperations
 		}
-    }
+	}
 
-    public var textDocumentSync: TwoTypeOption<TextDocumentSyncOptions, TextDocumentSyncKind>?
-    public var completionProvider: CompletionOptions?
-    public var hoverProvider: TwoTypeOption<Bool, HoverOptions>?
-    public var signatureHelpProvider: SignatureHelpOptions?
-    public var declarationProvider: ThreeTypeOption<Bool, DeclarationOptions, DeclarationRegistrationOptions>?
-    public var definitionProvider: TwoTypeOption<Bool, DefinitionOptions>?
-    public var typeDefinitionProvider: ThreeTypeOption<Bool, TypeDefinitionOptions, TypeDefinitionRegistrationOptions>?
-    public var implementationProvider: ThreeTypeOption<Bool, ImplementationOptions, ImplementationRegistrationOptions>?
-    public var referencesProvider: TwoTypeOption<Bool, ReferenceOptions>?
-    public var documentHighlightProvider: TwoTypeOption<Bool, DocumentHighlightOptions>?
-    public var documentSymbolProvider: TwoTypeOption<Bool, DocumentSymbolOptions>?
-    public var codeActionProvider: TwoTypeOption<Bool, CodeActionOptions>?
-    public var codeLensProvider: CodeLensOptions?
-    public var documentLinkProvider: DocumentLinkOptions?
-    public var colorProvider: ThreeTypeOption<Bool, DocumentColorOptions, DocumentColorRegistrationOptions>?
-    public var documentFormattingProvider: TwoTypeOption<Bool, DocumentFormattingOptions>?
-    public var documentRangeFormattingProvider: TwoTypeOption<Bool, DocumentRangeFormattingOptions>?
-    public var documentOnTypeFormattingProvider: DocumentOnTypeFormattingOptions?
-    public var renameProvider: TwoTypeOption<Bool, RenameOptions>?
-    public var foldingRangeProvider: ThreeTypeOption<Bool, FoldingRangeOptions, FoldingRangeRegistrationOptions>?
-    public var executeCommandProvider: ExecuteCommandOptions?
-    public var selectionRangeProvider: ThreeTypeOption<Bool, SelectionRangeOptions, SelectionRangeRegistrationOptions>?
-    public var linkedEditingRangeProvider: ThreeTypeOption<Bool, LinkedEditingRangeOptions, LinkedEditingRangeRegistrationOptions>?
-    public var callHierarchyProvider: ThreeTypeOption<Bool, CallHierarchyOptions, CallHierarchyRegistrationOptions>?
-    public var semanticTokensProvider: TwoTypeOption<SemanticTokensOptions, SemanticTokensRegistrationOptions>?
-    public var monikerProvider: ThreeTypeOption<Bool, MonikerOptions, MonikerRegistrationOptions>?
+	public var textDocumentSync: TwoTypeOption<TextDocumentSyncOptions, TextDocumentSyncKind>?
+	public var completionProvider: CompletionOptions?
+	public var hoverProvider: TwoTypeOption<Bool, HoverOptions>?
+	public var signatureHelpProvider: SignatureHelpOptions?
+	public var declarationProvider:
+		ThreeTypeOption<Bool, DeclarationOptions, DeclarationRegistrationOptions>?
+	public var definitionProvider: TwoTypeOption<Bool, DefinitionOptions>?
+	public var typeDefinitionProvider:
+		ThreeTypeOption<Bool, TypeDefinitionOptions, TypeDefinitionRegistrationOptions>?
+	public var implementationProvider:
+		ThreeTypeOption<Bool, ImplementationOptions, ImplementationRegistrationOptions>?
+	public var referencesProvider: TwoTypeOption<Bool, ReferenceOptions>?
+	public var documentHighlightProvider: TwoTypeOption<Bool, DocumentHighlightOptions>?
+	public var documentSymbolProvider: TwoTypeOption<Bool, DocumentSymbolOptions>?
+	public var codeActionProvider: TwoTypeOption<Bool, CodeActionOptions>?
+	public var codeLensProvider: CodeLensOptions?
+	public var documentLinkProvider: DocumentLinkOptions?
+	public var colorProvider:
+		ThreeTypeOption<Bool, DocumentColorOptions, DocumentColorRegistrationOptions>?
+	public var documentFormattingProvider: TwoTypeOption<Bool, DocumentFormattingOptions>?
+	public var documentRangeFormattingProvider: TwoTypeOption<Bool, DocumentRangeFormattingOptions>?
+	public var documentOnTypeFormattingProvider: DocumentOnTypeFormattingOptions?
+	public var renameProvider: TwoTypeOption<Bool, RenameOptions>?
+	public var foldingRangeProvider:
+		ThreeTypeOption<Bool, FoldingRangeOptions, FoldingRangeRegistrationOptions>?
+	public var executeCommandProvider: ExecuteCommandOptions?
+	public var selectionRangeProvider:
+		ThreeTypeOption<Bool, SelectionRangeOptions, SelectionRangeRegistrationOptions>?
+	public var linkedEditingRangeProvider:
+		ThreeTypeOption<Bool, LinkedEditingRangeOptions, LinkedEditingRangeRegistrationOptions>?
+	public var callHierarchyProvider:
+		ThreeTypeOption<Bool, CallHierarchyOptions, CallHierarchyRegistrationOptions>?
+	public var semanticTokensProvider:
+		TwoTypeOption<SemanticTokensOptions, SemanticTokensRegistrationOptions>?
+	public var monikerProvider: ThreeTypeOption<Bool, MonikerOptions, MonikerRegistrationOptions>?
 	public var diagnosticProvider: TwoTypeOption<DiagnosticOptions, DiagnosticRegistrationOptions>?
-    public var workspaceSymbolProvider: TwoTypeOption<Bool, WorkspaceSymbolOptions>?
-    public var workspace: Workspace?
-    public var experimental: LSPAny?
+	public var workspaceSymbolProvider: TwoTypeOption<Bool, WorkspaceSymbolOptions>?
+	public var workspace: Workspace?
+	public var experimental: LSPAny?
 
 	public init() {
 	}

--- a/Sources/LanguageServerProtocol/TextSynchronization.swift
+++ b/Sources/LanguageServerProtocol/TextSynchronization.swift
@@ -1,162 +1,166 @@
 import Foundation
 
 public struct DidOpenTextDocumentParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentItem
+	public let textDocument: TextDocumentItem
 
-    public init(textDocument: TextDocumentItem) {
-        self.textDocument = textDocument
-    }
+	public init(textDocument: TextDocumentItem) {
+		self.textDocument = textDocument
+	}
 }
 
 public struct TextDocumentContentChangeEvent: Codable, Hashable, Sendable {
-    public let range: LSPRange?
-    public let rangeLength: Int?
-    public let text: String
+	public let range: LSPRange?
+	public let rangeLength: Int?
+	public let text: String
 
-    public init(range: LSPRange?, rangeLength: Int?, text: String) {
-        self.range = range
-        self.rangeLength = rangeLength
-        self.text = text
-    }
+	public init(range: LSPRange?, rangeLength: Int?, text: String) {
+		self.range = range
+		self.rangeLength = rangeLength
+		self.text = text
+	}
 }
 
 public struct DidChangeTextDocumentParams: Codable, Hashable, Sendable {
-    public let textDocument: VersionedTextDocumentIdentifier
-    public let contentChanges: [TextDocumentContentChangeEvent]
+	public let textDocument: VersionedTextDocumentIdentifier
+	public let contentChanges: [TextDocumentContentChangeEvent]
 
-    public init(textDocument: VersionedTextDocumentIdentifier, contentChanges: [TextDocumentContentChangeEvent]) {
-        self.textDocument = textDocument
-        self.contentChanges = contentChanges
-    }
+	public init(
+		textDocument: VersionedTextDocumentIdentifier,
+		contentChanges: [TextDocumentContentChangeEvent]
+	) {
+		self.textDocument = textDocument
+		self.contentChanges = contentChanges
+	}
 
-    public init(uri: DocumentUri, version: Int, contentChanges: [TextDocumentContentChangeEvent]) {
-        self.textDocument = VersionedTextDocumentIdentifier(uri: uri, version: version)
-        self.contentChanges = contentChanges
-    }
+	public init(uri: DocumentUri, version: Int, contentChanges: [TextDocumentContentChangeEvent]) {
+		self.textDocument = VersionedTextDocumentIdentifier(uri: uri, version: version)
+		self.contentChanges = contentChanges
+	}
 
-    public init(uri: DocumentUri, version: Int, contentChange: TextDocumentContentChangeEvent) {
-        self.textDocument = VersionedTextDocumentIdentifier(uri: uri, version: version)
-        self.contentChanges = [contentChange]
-    }
+	public init(uri: DocumentUri, version: Int, contentChange: TextDocumentContentChangeEvent) {
+		self.textDocument = VersionedTextDocumentIdentifier(uri: uri, version: version)
+		self.contentChanges = [contentChange]
+	}
 }
 
 public struct TextDocumentChangeRegistrationOptions: Codable, Hashable, Sendable {
-    public let documentSelector: DocumentSelector?
-    public let syncKind: TextDocumentSyncKind
+	public let documentSelector: DocumentSelector?
+	public let syncKind: TextDocumentSyncKind
 }
 
 public struct DidSaveTextDocumentParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
-    public let text: String?
+	public let textDocument: TextDocumentIdentifier
+	public let text: String?
 
-    public init(textDocument: TextDocumentIdentifier, text: String? = nil) {
-        self.textDocument = textDocument
-        self.text = text
-    }
+	public init(textDocument: TextDocumentIdentifier, text: String? = nil) {
+		self.textDocument = textDocument
+		self.text = text
+	}
 
-    public init(uri: DocumentUri, text: String? = nil) {
-        let docId = TextDocumentIdentifier(uri: uri)
+	public init(uri: DocumentUri, text: String? = nil) {
+		let docId = TextDocumentIdentifier(uri: uri)
 
-        self.textDocument = docId
-        self.text = text
-    }
+		self.textDocument = docId
+		self.text = text
+	}
 }
 
 public struct TextDocumentSaveRegistrationOptions: Codable, Hashable, Sendable {
-    public let documentSelector: DocumentSelector?
-    public let includeText: Bool?
+	public let documentSelector: DocumentSelector?
+	public let includeText: Bool?
 }
 
 public struct DidCloseTextDocumentParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
+	public let textDocument: TextDocumentIdentifier
 
-    public init(textDocument: TextDocumentIdentifier) {
-        self.textDocument = textDocument
-    }
+	public init(textDocument: TextDocumentIdentifier) {
+		self.textDocument = textDocument
+	}
 
-    public init(uri: DocumentUri) {
-        let docId = TextDocumentIdentifier(uri: uri)
+	public init(uri: DocumentUri) {
+		let docId = TextDocumentIdentifier(uri: uri)
 
-        self.init(textDocument: docId)
-    }
+		self.init(textDocument: docId)
+	}
 }
 
 public enum TextDocumentSaveReason: Int, Codable, Hashable, Sendable {
-    case manual = 1
-    case afterDelay = 2
-    case focusOut = 3
+	case manual = 1
+	case afterDelay = 2
+	case focusOut = 3
 }
 
 public struct WillSaveTextDocumentParams: Codable, Hashable, Sendable {
-    public let textDocument: TextDocumentIdentifier
-    public let reason: TextDocumentSaveReason
+	public let textDocument: TextDocumentIdentifier
+	public let reason: TextDocumentSaveReason
 
-    public init(textDocument: TextDocumentIdentifier, reason: TextDocumentSaveReason) {
-        self.textDocument = textDocument
-        self.reason = reason
-    }
+	public init(textDocument: TextDocumentIdentifier, reason: TextDocumentSaveReason) {
+		self.textDocument = textDocument
+		self.reason = reason
+	}
 }
 
 public typealias WillSaveWaitUntilResponse = [TextEdit]?
 
 public struct TextEdit: Codable, Hashable, Sendable {
-    public let range: LSPRange
-    public let newText: String
+	public let range: LSPRange
+	public let newText: String
 
-    public init(range: LSPRange, newText: String) {
-        self.range = range
-        self.newText = newText
-    }
+	public init(range: LSPRange, newText: String) {
+		self.range = range
+		self.newText = newText
+	}
 
-    public var isNoOp: Bool {
-        return range.isEmpty && newText.isEmpty
-    }
+	public var isNoOp: Bool {
+		return range.isEmpty && newText.isEmpty
+	}
 
-    public var isInsert: Bool {
-        return range.isEmpty && (newText.isEmpty == false)
-    }
+	public var isInsert: Bool {
+		return range.isEmpty && (newText.isEmpty == false)
+	}
 
-    /// Adjusts the input array so that it can be applied, in order
-    /// to produce the desired final state
-    ///
-    /// This function *requires* the input edits to meet the LSP spec. In
-    /// particular:
-    /// - overlaps are not allowed
-    /// - inserts with the same starting location must be applied in the order
-    ///   they appear in the array.
-    public static func makeApplicable(_ edits: [TextEdit]) -> [TextEdit] {
-        var finalEdits = [TextEdit]()
+	/// Adjusts the input array so that it can be applied, in order
+	/// to produce the desired final state
+	///
+	/// This function *requires* the input edits to meet the LSP spec. In
+	/// particular:
+	/// - overlaps are not allowed
+	/// - inserts with the same starting location must be applied in the order
+	///   they appear in the array.
+	public static func makeApplicable(_ edits: [TextEdit]) -> [TextEdit] {
+		var finalEdits = [TextEdit]()
 
-        for edit in edits {
-            if edit.isNoOp {
-                continue
-            }
+		for edit in edits {
+			if edit.isNoOp {
+				continue
+			}
 
-            guard let last = finalEdits.last else {
-                finalEdits.append(edit)
-                continue
-            }
+			guard let last = finalEdits.last else {
+				finalEdits.append(edit)
+				continue
+			}
 
-            guard edit.isInsert && last.isInsert && edit.range == last.range else {
-                finalEdits.append(edit)
-                continue
-            }
+			guard edit.isInsert && last.isInsert && edit.range == last.range else {
+				finalEdits.append(edit)
+				continue
+			}
 
-            let combinedEdit = TextEdit(range: edit.range,
-                                        newText: last.newText + edit.newText)
+			let combinedEdit = TextEdit(
+				range: edit.range,
+				newText: last.newText + edit.newText)
 
-            finalEdits.removeLast()
-            finalEdits.append(combinedEdit)
-        }
+			finalEdits.removeLast()
+			finalEdits.append(combinedEdit)
+		}
 
-        return finalEdits.sorted(by: {
-            return $1.range.start < $0.range.start
-        })
-    }
+		return finalEdits.sorted(by: {
+			return $1.range.start < $0.range.start
+		})
+	}
 }
 
 extension TextEdit: CustomStringConvertible {
-    public var description: String {
-        return "\(range): \"\(newText)\""
-    }
+	public var description: String {
+		return "\(range): \"\(newText)\""
+	}
 }

--- a/Sources/LanguageServerProtocol/ThreeTypeOption.swift
+++ b/Sources/LanguageServerProtocol/ThreeTypeOption.swift
@@ -1,41 +1,41 @@
 import Foundation
 
 public enum ThreeTypeOption<T, U, V> {
-    case optionA(T)
-    case optionB(U)
-    case optionC(V)
+	case optionA(T)
+	case optionB(U)
+	case optionC(V)
 }
 
 extension ThreeTypeOption: Codable where T: Codable, U: Codable, V: Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.singleValueContainer()
 
-        do {
-            let value = try container.decode(T.self)
-            self = .optionA(value)
-        } catch is DecodingError {
-            do {
-                let value = try container.decode(U.self)
-                self = .optionB(value)
-            } catch is DecodingError {
-                let value = try container.decode(V.self)
-                self = .optionC(value)
-            }
-        }
-    }
+		do {
+			let value = try container.decode(T.self)
+			self = .optionA(value)
+		} catch is DecodingError {
+			do {
+				let value = try container.decode(U.self)
+				self = .optionB(value)
+			} catch is DecodingError {
+				let value = try container.decode(V.self)
+				self = .optionC(value)
+			}
+		}
+	}
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.singleValueContainer()
 
-        switch self {
-        case .optionA(let value):
-            try container.encode(value)
-        case .optionB(let value):
-            try container.encode(value)
-        case .optionC(let value):
-            try container.encode(value)
-        }
-    }
+		switch self {
+		case .optionA(let value):
+			try container.encode(value)
+		case .optionB(let value):
+			try container.encode(value)
+		case .optionC(let value):
+			try container.encode(value)
+		}
+	}
 }
 
 extension ThreeTypeOption: Equatable where T: Equatable, U: Equatable, V: Equatable {}

--- a/Sources/LanguageServerProtocol/TwoTypeOption.swift
+++ b/Sources/LanguageServerProtocol/TwoTypeOption.swift
@@ -1,33 +1,33 @@
 import Foundation
 
 public enum TwoTypeOption<T, U> {
-    case optionA(T)
-    case optionB(U)
+	case optionA(T)
+	case optionB(U)
 }
 
 extension TwoTypeOption: Codable where T: Codable, U: Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.singleValueContainer()
 
-        do {
-            let value = try container.decode(T.self)
-            self = .optionA(value)
-        } catch is DecodingError {
-            let value = try container.decode(U.self)
-            self = .optionB(value)
-        }
-    }
+		do {
+			let value = try container.decode(T.self)
+			self = .optionA(value)
+		} catch is DecodingError {
+			let value = try container.decode(U.self)
+			self = .optionB(value)
+		}
+	}
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.singleValueContainer()
 
-        switch self {
-        case .optionA(let value):
-            try container.encode(value)
-        case .optionB(let value):
-            try container.encode(value)
-        }
-    }
+		switch self {
+		case .optionA(let value):
+			try container.encode(value)
+		case .optionB(let value):
+			try container.encode(value)
+		}
+	}
 }
 
 extension TwoTypeOption: Equatable where T: Equatable, U: Equatable {

--- a/Sources/LanguageServerProtocol/Utility.swift
+++ b/Sources/LanguageServerProtocol/Utility.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public struct GenericDynamicRegistration: Codable, Hashable, Sendable {
-    public let dynamicRegistration: Bool?
+	public let dynamicRegistration: Bool?
 
-    public init(dynamicRegistration: Bool) {
-        self.dynamicRegistration = dynamicRegistration
-    }
+	public init(dynamicRegistration: Bool) {
+		self.dynamicRegistration = dynamicRegistration
+	}
 }

--- a/Sources/LanguageServerProtocol/Window.swift
+++ b/Sources/LanguageServerProtocol/Window.swift
@@ -1,30 +1,30 @@
 import Foundation
 
 public enum MessageType: Int, Codable, Hashable, Sendable {
-    case error = 1
-    case warning = 2
-    case info = 3
-    case log = 4
+	case error = 1
+	case warning = 2
+	case info = 3
+	case log = 4
 }
 
 extension MessageType: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .error:
-            return "error"
-        case .warning:
-            return "warning"
-        case .info:
-            return "info"
-        case .log:
-            return "log"
-        }
-    }
+	public var description: String {
+		switch self {
+		case .error:
+			return "error"
+		case .warning:
+			return "warning"
+		case .info:
+			return "info"
+		case .log:
+			return "log"
+		}
+	}
 }
 
 public struct LogMessageParams: Codable, Hashable, Sendable {
-    public let type: MessageType
-    public let message: String
+	public let type: MessageType
+	public let message: String
 
 	public init(type: MessageType, message: String) {
 		self.type = type
@@ -33,33 +33,34 @@ public struct LogMessageParams: Codable, Hashable, Sendable {
 }
 
 extension LogMessageParams: CustomStringConvertible {
-    public var description: String {
-        return "\(type): \(message)"
-    }
+	public var description: String {
+		return "\(type): \(message)"
+	}
 }
 
 public typealias ShowMessageParams = LogMessageParams
 
 public struct ShowDocumentParams: Hashable, Codable, Sendable {
-    public var uri: URI
-    public var external: Bool?
-    public var takeFocus: Bool?
-    public var selection: LSPRange?
+	public var uri: URI
+	public var external: Bool?
+	public var takeFocus: Bool?
+	public var selection: LSPRange?
 
-    public init(uri: URI, external: Bool? = nil, takeFocus: Bool? = nil, selection: LSPRange? = nil) {
-        self.uri = uri
-        self.external = external
-        self.takeFocus = takeFocus
-        self.selection = selection
-    }
+	public init(uri: URI, external: Bool? = nil, takeFocus: Bool? = nil, selection: LSPRange? = nil)
+	{
+		self.uri = uri
+		self.external = external
+		self.takeFocus = takeFocus
+		self.selection = selection
+	}
 }
 
 public struct WorkDoneProgressCreateParams: Hashable, Codable, Sendable {
-    public var token: ProgressToken
+	public var token: ProgressToken
 
-    public init(token: ProgressToken) {
-        self.token = token
-    }
+	public init(token: ProgressToken) {
+		self.token = token
+	}
 }
 
 public typealias WorkDoneProgressCancelParams = WorkDoneProgressCreateParams

--- a/Sources/LanguageServerProtocol/Window/ShowMessageRequest.swift
+++ b/Sources/LanguageServerProtocol/Window/ShowMessageRequest.swift
@@ -1,19 +1,19 @@
 import Foundation
 
 public struct MessageActionItem: Codable, Hashable, Sendable {
-    public var title: String
+	public var title: String
 }
 
 public struct ShowMessageRequestParams: Codable, Hashable, Sendable {
-    public var type: MessageType
-    public var message: String
-    public var actions: [MessageActionItem]?
+	public var type: MessageType
+	public var message: String
+	public var actions: [MessageActionItem]?
 }
 
 extension ShowMessageRequestParams: CustomStringConvertible {
-    public var description: String {
-        return "\(type): \(message)"
-    }
+	public var description: String {
+		return "\(type): \(message)"
+	}
 }
 
 public typealias ShowMessageRequestResponse = MessageActionItem?

--- a/Sources/LanguageServerProtocol/Workspace.swift
+++ b/Sources/LanguageServerProtocol/Workspace.swift
@@ -1,106 +1,109 @@
 import Foundation
 
 public struct WatchKind: OptionSet, Codable, Hashable, Sendable {
-    public let rawValue: Int
+	public let rawValue: Int
 
-    public init(rawValue: Int) {
-        self.rawValue = rawValue
-    }
+	public init(rawValue: Int) {
+		self.rawValue = rawValue
+	}
 
-    public static let create = WatchKind(rawValue: 1)
-    public static let change = WatchKind(rawValue: 2)
-    public static let delete = WatchKind(rawValue: 4)
+	public static let create = WatchKind(rawValue: 1)
+	public static let change = WatchKind(rawValue: 2)
+	public static let delete = WatchKind(rawValue: 4)
 
-    public static let all: WatchKind = [.create, .change, .delete]
+	public static let all: WatchKind = [.create, .change, .delete]
 }
 
 public struct FileSystemWatcher: Codable, Hashable, Sendable {
-    public var globPattern: String
-    public var kind: WatchKind?
+	public var globPattern: String
+	public var kind: WatchKind?
 
-    public init(globPattern: String, kind: WatchKind? = nil) {
-        self.globPattern = globPattern
-        self.kind = kind
-    }
+	public init(globPattern: String, kind: WatchKind? = nil) {
+		self.globPattern = globPattern
+		self.kind = kind
+	}
 }
 
 public struct DidChangeWatchedFilesRegistrationOptions: Codable, Hashable, Sendable {
-    public var watchers: [FileSystemWatcher]
+	public var watchers: [FileSystemWatcher]
 }
 
 public enum FileChangeType: Int, Codable, Hashable, Sendable {
-    case created = 1
-    case changed = 2
-    case deleted = 3
+	case created = 1
+	case changed = 2
+	case deleted = 3
 }
 
 public struct FileEvent: Codable, Hashable, Sendable {
-    public var uri: DocumentUri
-    public var type: FileChangeType
+	public var uri: DocumentUri
+	public var type: FileChangeType
 
-    public init(uri: DocumentUri, type: FileChangeType) {
-        self.uri = uri
-        self.type = type
-    }
+	public init(uri: DocumentUri, type: FileChangeType) {
+		self.uri = uri
+		self.type = type
+	}
 }
 
 public struct DidChangeWatchedFilesParams: Codable, Hashable, Sendable {
-    public var changes: [FileEvent]
+	public var changes: [FileEvent]
 
-    public init(changes: [FileEvent]) {
-        self.changes = changes
-    }
+	public init(changes: [FileEvent]) {
+		self.changes = changes
+	}
 }
 
 public struct WorkspaceFolder: Codable, Hashable, Sendable {
-    public let uri: String
-    public let name: String
+	public let uri: String
+	public let name: String
 
-    public init(uri: String, name: String) {
-        self.uri = uri
-        self.name = name
-    }
+	public init(uri: String, name: String) {
+		self.uri = uri
+		self.name = name
+	}
 }
 
 public struct WorkspaceFoldersChangeEvent: Codable, Hashable, Sendable {
-    public var added: [WorkspaceFolder]
-    public var removed: [WorkspaceFolder]
+	public var added: [WorkspaceFolder]
+	public var removed: [WorkspaceFolder]
 
-    public init(added: [WorkspaceFolder], removed: [WorkspaceFolder]) {
-        self.added = added
-        self.removed = removed
-    }
+	public init(added: [WorkspaceFolder], removed: [WorkspaceFolder]) {
+		self.added = added
+		self.removed = removed
+	}
 }
 
 public struct DidChangeWorkspaceFoldersParams: Codable, Hashable, Sendable {
-    public var event: WorkspaceFoldersChangeEvent
+	public var event: WorkspaceFoldersChangeEvent
 
-    public init(event: WorkspaceFoldersChangeEvent) {
-        self.event = event
-    }
+	public init(event: WorkspaceFoldersChangeEvent) {
+		self.event = event
+	}
 }
 
 public struct DidChangeConfigurationParams: Codable, Hashable, Sendable {
-    public var settings: LSPAny?
+	public var settings: LSPAny?
 
-    public init(settings: LSPAny) {
-        self.settings = settings
-    }
+	public init(settings: LSPAny) {
+		self.settings = settings
+	}
 }
 
 public enum SymbolTag: Int, Codable, Hashable, CaseIterable, Sendable {
-    case Deprecated = 1
+	case Deprecated = 1
 }
 
 public struct SymbolInformation: Codable, Hashable, Sendable {
-    public let name: String
-    public let kind: SymbolKind
-    public let tags: [SymbolTag]?
-    public let deprecated: Bool?
-    public let location: Location
-    public let containerName: String?
+	public let name: String
+	public let kind: SymbolKind
+	public let tags: [SymbolTag]?
+	public let deprecated: Bool?
+	public let location: Location
+	public let containerName: String?
 
-	public init(name: String, kind: SymbolKind, tags: [SymbolTag]? = nil, deprecated: Bool? = nil, location: Location, containerName: String? = nil) {
+	public init(
+		name: String, kind: SymbolKind, tags: [SymbolTag]? = nil, deprecated: Bool? = nil,
+		location: Location, containerName: String? = nil
+	) {
 		self.name = name
 		self.kind = kind
 		self.tags = tags
@@ -111,79 +114,79 @@ public struct SymbolInformation: Codable, Hashable, Sendable {
 }
 
 public struct CreateFileOptions: Codable, Hashable, Sendable {
-    public let overwrite: Bool?
-    public let ignoreIfExists: Bool?
+	public let overwrite: Bool?
+	public let ignoreIfExists: Bool?
 }
 
 public struct CreateFile: Codable, Hashable, Sendable {
-   public  let kind: String
-    public let uri: DocumentUri
-    public let options: CreateFileOptions?
+	public let kind: String
+	public let uri: DocumentUri
+	public let options: CreateFileOptions?
 }
 
 public typealias RenameFileOptions = CreateFileOptions
 
 public struct RenameFile: Codable, Hashable, Sendable {
-    public let kind: String
-    public let oldUri: DocumentUri
-    public let newUri: DocumentUri
-    public let options: RenameFileOptions
+	public let kind: String
+	public let oldUri: DocumentUri
+	public let newUri: DocumentUri
+	public let options: RenameFileOptions
 }
 
 public struct DeleteFileOptions: Codable, Hashable, Sendable {
-    public let recursive: Bool?
-    public let ignoreIfNotExists: Bool?
+	public let recursive: Bool?
+	public let ignoreIfNotExists: Bool?
 }
 
 public struct DeleteFile: Codable, Hashable, Sendable {
-    public let kind: String
-    public let uri: DocumentUri
-    public let options: DeleteFileOptions
+	public let kind: String
+	public let uri: DocumentUri
+	public let options: DeleteFileOptions
 }
 
 public struct TextDocumentEdit: Codable, Hashable, Sendable {
-    public let textDocument: VersionedTextDocumentIdentifier
-    public let edits: [TextEdit]
+	public let textDocument: VersionedTextDocumentIdentifier
+	public let edits: [TextEdit]
 }
 
 public enum WorkspaceEditDocumentChange: Codable, Hashable, Sendable {
-    case textDocumentEdit(TextDocumentEdit)
-    case createFile(CreateFile)
-    case renameFile(RenameFile)
-    case deleteFile(DeleteFile)
+	case textDocumentEdit(TextDocumentEdit)
+	case createFile(CreateFile)
+	case renameFile(RenameFile)
+	case deleteFile(DeleteFile)
 
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.singleValueContainer()
 
-        if let value = try? container.decode(TextDocumentEdit.self) {
-            self = .textDocumentEdit(value)
-        } else if let value = try? container.decode(CreateFile.self) {
-            self = .createFile(value)
-        } else if let value = try? container.decode(RenameFile.self) {
-            self = .renameFile(value)
-        } else {
-            let value = try container.decode(DeleteFile.self)
-            self = .deleteFile(value)
-        }
-    }
+		if let value = try? container.decode(TextDocumentEdit.self) {
+			self = .textDocumentEdit(value)
+		} else if let value = try? container.decode(CreateFile.self) {
+			self = .createFile(value)
+		} else if let value = try? container.decode(RenameFile.self) {
+			self = .renameFile(value)
+		} else {
+			let value = try container.decode(DeleteFile.self)
+			self = .deleteFile(value)
+		}
+	}
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.singleValueContainer()
 
-        switch self {
-        case .textDocumentEdit(let value):
-            try container.encode(value)
-        case .createFile(let value):
-            try container.encode(value)
-        case .renameFile(let value):
-            try container.encode(value)
-        case .deleteFile(let value):
-            try container.encode(value)
-        }
-    }
+		switch self {
+		case .textDocumentEdit(let value):
+			try container.encode(value)
+		case .createFile(let value):
+			try container.encode(value)
+		case .renameFile(let value):
+			try container.encode(value)
+		case .deleteFile(let value):
+			try container.encode(value)
+		}
+	}
 }
 
 public struct WorkspaceEdit: Codable, Hashable, Sendable {
-    public let changes: [DocumentUri : [TextEdit]]?
-    public let documentChanges: [WorkspaceEditDocumentChange]?
+	public let changes: [DocumentUri: [TextEdit]]?
+	public let documentChanges: [WorkspaceEditDocumentChange]?
 }

--- a/Sources/LanguageServerProtocol/Workspace/ApplyEdit.swift
+++ b/Sources/LanguageServerProtocol/Workspace/ApplyEdit.swift
@@ -1,23 +1,23 @@
 import Foundation
 
 public struct ApplyWorkspaceEditParams: Codable, Hashable, Sendable {
-    public var label: String?
-    public var edit: WorkspaceEdit
+	public var label: String?
+	public var edit: WorkspaceEdit
 
-    public init(label: String? = nil, edit: WorkspaceEdit) {
-        self.label = label
-        self.edit = edit
-    }
+	public init(label: String? = nil, edit: WorkspaceEdit) {
+		self.label = label
+		self.edit = edit
+	}
 }
 
 public struct ApplyWorkspaceEditResult: Codable, Hashable, Sendable {
-    public var applied: Bool
-    public var failureReason: String?
-    public var failedChange: UInt?
+	public var applied: Bool
+	public var failureReason: String?
+	public var failedChange: UInt?
 
-    public init(applied: Bool, failureReason: String? = nil, failedChange: UInt? = nil) {
-        self.applied = applied
-        self.failureReason = failureReason
-        self.failedChange = failedChange
-    }
+	public init(applied: Bool, failureReason: String? = nil, failedChange: UInt? = nil) {
+		self.applied = applied
+		self.failureReason = failureReason
+		self.failedChange = failedChange
+	}
 }

--- a/Sources/LanguageServerProtocol/Workspace/Configuration.swift
+++ b/Sources/LanguageServerProtocol/Workspace/Configuration.swift
@@ -1,19 +1,19 @@
 import Foundation
 
 public struct ConfigurationItem: Codable, Hashable, Sendable {
-    public var scopeUri: DocumentUri?
-    public var section: String?
+	public var scopeUri: DocumentUri?
+	public var section: String?
 
-    public init(scopeUri: DocumentUri?, section: String?) {
-        self.scopeUri = scopeUri
-        self.section = section
-    }
+	public init(scopeUri: DocumentUri?, section: String?) {
+		self.scopeUri = scopeUri
+		self.section = section
+	}
 }
 
 public struct ConfigurationParams: Codable, Hashable, Sendable {
-    public var items: [ConfigurationItem]
+	public var items: [ConfigurationItem]
 
-    public init(items: [ConfigurationItem]) {
-        self.items = items
-    }
+	public init(items: [ConfigurationItem]) {
+		self.items = items
+	}
 }

--- a/Sources/LanguageServerProtocol/Workspace/ExecuteCommand.swift
+++ b/Sources/LanguageServerProtocol/Workspace/ExecuteCommand.swift
@@ -3,27 +3,27 @@ import Foundation
 public typealias ExecuteCommandClientCapabilities = DynamicRegistrationClientCapabilities
 
 public struct ExecuteCommandOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var commands: [String]
+	public var workDoneProgress: Bool?
+	public var commands: [String]
 
-    public init(workDoneProgress: Bool? = nil, commands: [String]) {
-        self.workDoneProgress = workDoneProgress
-        self.commands = commands
-    }
+	public init(workDoneProgress: Bool? = nil, commands: [String]) {
+		self.workDoneProgress = workDoneProgress
+		self.commands = commands
+	}
 }
 
 public typealias ExecuteCommandRegistrationOptions = ExecuteCommandOptions
 
 public struct ExecuteCommandParams: Codable, Hashable, Sendable {
-    public var workDoneToken: ProgressToken?
-    public var command: String
-    public var arguments: [LSPAny]?
+	public var workDoneToken: ProgressToken?
+	public var command: String
+	public var arguments: [LSPAny]?
 
-    public init(workDoneToken: ProgressToken? = nil, command: String, arguments: [LSPAny]? = nil) {
-        self.workDoneToken = workDoneToken
-        self.command = command
-        self.arguments = arguments
-    }
+	public init(workDoneToken: ProgressToken? = nil, command: String, arguments: [LSPAny]? = nil) {
+		self.workDoneToken = workDoneToken
+		self.command = command
+		self.arguments = arguments
+	}
 }
 
 public typealias ExecuteCommandResponse = LSPAny

--- a/Sources/LanguageServerProtocol/Workspace/Symbol.swift
+++ b/Sources/LanguageServerProtocol/Workspace/Symbol.swift
@@ -1,55 +1,64 @@
 import Foundation
 
 public struct WorkspaceSymbolClientCapabilities: Codable, Hashable, Sendable {
-    public struct Properties: Codable, Hashable, Sendable {
-        public var properties: [String]
-    }
+	public struct Properties: Codable, Hashable, Sendable {
+		public var properties: [String]
+	}
 
-    public var dynamicRegistration: Bool?
-    public var symbolKind: ValueSet<SymbolKind>?
-    public var tagSupport: ValueSet<SymbolTag>?
-    public var resolveSupport: Properties?
+	public var dynamicRegistration: Bool?
+	public var symbolKind: ValueSet<SymbolKind>?
+	public var tagSupport: ValueSet<SymbolTag>?
+	public var resolveSupport: Properties?
 
-    public init(dynamicRegistration: Bool?, symbolKind: [SymbolKind]?, tagSupport: [SymbolTag]?, resolveSupport: Properties?) {
-        self.dynamicRegistration = dynamicRegistration
-        self.symbolKind = symbolKind.map { ValueSet(valueSet: $0) }
-        self.tagSupport = tagSupport.map { ValueSet(valueSet: $0) }
-        self.resolveSupport = resolveSupport
-    }
+	public init(
+		dynamicRegistration: Bool?, symbolKind: [SymbolKind]?, tagSupport: [SymbolTag]?,
+		resolveSupport: Properties?
+	) {
+		self.dynamicRegistration = dynamicRegistration
+		self.symbolKind = symbolKind.map { ValueSet(valueSet: $0) }
+		self.tagSupport = tagSupport.map { ValueSet(valueSet: $0) }
+		self.resolveSupport = resolveSupport
+	}
 
-    public init(dynamicRegistration: Bool?, symbolKind: [SymbolKind]?, tagSupport: [SymbolTag]?, resolveSupport: [String]?) {
-        self.init(dynamicRegistration: dynamicRegistration,
-                  symbolKind: symbolKind,
-                  tagSupport: tagSupport,
-                  resolveSupport: resolveSupport.map { Properties(properties: $0) })
-    }
+	public init(
+		dynamicRegistration: Bool?, symbolKind: [SymbolKind]?, tagSupport: [SymbolTag]?,
+		resolveSupport: [String]?
+	) {
+		self.init(
+			dynamicRegistration: dynamicRegistration,
+			symbolKind: symbolKind,
+			tagSupport: tagSupport,
+			resolveSupport: resolveSupport.map { Properties(properties: $0) })
+	}
 }
 
 public struct WorkspaceSymbolOptions: Codable, Hashable, Sendable {
-    public var workDoneProgress: Bool?
-    public var resolveProvider: Bool?
+	public var workDoneProgress: Bool?
+	public var resolveProvider: Bool?
 }
 
 public typealias WorkspaceSymbolRegistrationOptions = WorkspaceSymbolOptions
 
 public struct WorkspaceSymbolParams: Codable, Hashable, Sendable {
-    public var workDoneToken: ProgressToken?
-    public var partialResultToken: ProgressToken?
-    public var query: String
+	public var workDoneToken: ProgressToken?
+	public var partialResultToken: ProgressToken?
+	public var query: String
 
-    public init(query: String, workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil) {
-        self.workDoneToken = workDoneToken
-        self.partialResultToken = partialResultToken
-        self.query = query
-    }
+	public init(
+		query: String, workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil
+	) {
+		self.workDoneToken = workDoneToken
+		self.partialResultToken = partialResultToken
+		self.query = query
+	}
 }
 
 public struct WorkspaceSymbol: Codable, Hashable, Sendable {
-    public var name: String
-    public var kind: SymbolKind
-    public var tags: [SymbolTag]?
-    public var location: TwoTypeOption<Location, TextDocumentIdentifier>?
-    public var containerName: String?
+	public var name: String
+	public var kind: SymbolKind
+	public var tags: [SymbolTag]?
+	public var location: TwoTypeOption<Location, TextDocumentIdentifier>?
+	public var containerName: String?
 }
 
-public typealias WorkspaceSymbolResponse = TwoTypeOption<[SymbolInformation],[WorkspaceSymbol]>?
+public typealias WorkspaceSymbolResponse = TwoTypeOption<[SymbolInformation], [WorkspaceSymbol]>?

--- a/Sources/LanguageServerProtocol/Workspace/WillCreateFiles.swift
+++ b/Sources/LanguageServerProtocol/Workspace/WillCreateFiles.swift
@@ -1,62 +1,64 @@
 import Foundation
 
 public enum FileOperationPatternKind: String, Codable, Hashable, Sendable {
-    case file = "file"
-    case folder = "folder"
+	case file = "file"
+	case folder = "folder"
 }
 
 public struct FileOperationPatternOptions: Codable, Hashable, Sendable {
-    public var ignoreCase: Bool?
+	public var ignoreCase: Bool?
 
-    public init(ignoreCase: Bool? = nil) {
-        self.ignoreCase = ignoreCase
-    }
+	public init(ignoreCase: Bool? = nil) {
+		self.ignoreCase = ignoreCase
+	}
 }
 
 public struct FileOperationPattern: Codable, Hashable, Sendable {
-    public let glob: String
-    public let matches: FileOperationPatternKind?
-    public let options: FileOperationPatternOptions?
+	public let glob: String
+	public let matches: FileOperationPatternKind?
+	public let options: FileOperationPatternOptions?
 
-    public init(glob: String, matches: FileOperationPatternKind?, options: FileOperationPatternOptions?) {
-        self.glob = glob
-        self.matches = matches
-        self.options = options
-    }
+	public init(
+		glob: String, matches: FileOperationPatternKind?, options: FileOperationPatternOptions?
+	) {
+		self.glob = glob
+		self.matches = matches
+		self.options = options
+	}
 }
 
 public struct FileOperationFilter: Codable, Hashable, Sendable {
-    public var scheme: String?
-    public var pattern: FileOperationPattern
+	public var scheme: String?
+	public var pattern: FileOperationPattern
 
-    public init(scheme: String? = nil, pattern: FileOperationPattern) {
-        self.scheme = scheme
-        self.pattern = pattern
-    }
+	public init(scheme: String? = nil, pattern: FileOperationPattern) {
+		self.scheme = scheme
+		self.pattern = pattern
+	}
 }
 
 public struct FileOperationRegistrationOptions: Codable, Hashable, Sendable {
-    public var filters: [FileOperationFilter]
+	public var filters: [FileOperationFilter]
 
-    public init(filters: [FileOperationFilter]) {
-        self.filters = filters
-    }
+	public init(filters: [FileOperationFilter]) {
+		self.filters = filters
+	}
 }
 
 public struct CreateFilesParams: Codable, Hashable, Sendable {
-    public var files: [FileCreate]
+	public var files: [FileCreate]
 
-    public init(files: [FileCreate]) {
-        self.files = files
-    }
+	public init(files: [FileCreate]) {
+		self.files = files
+	}
 }
 
 public struct FileCreate: Codable, Hashable, Sendable {
-    public var uri: String
+	public var uri: String
 
-    public init(uri: String) {
-        self.uri = uri
-    }
+	public init(uri: String) {
+		self.uri = uri
+	}
 }
 
 public typealias WorkspaceWillCreateFilesResponse = WorkspaceEdit?

--- a/Sources/LanguageServerProtocol/Workspace/WillDeleteFiles.swift
+++ b/Sources/LanguageServerProtocol/Workspace/WillDeleteFiles.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 public struct DeleteFilesParams: Codable, Hashable, Sendable {
-    public var files: [FileDelete]
+	public var files: [FileDelete]
 }
 
 public struct FileDelete: Codable, Hashable, Sendable {
-    public var uri: String
+	public var uri: String
 
-    public init(uri: String) {
-        self.uri = uri
-    }
+	public init(uri: String) {
+		self.uri = uri
+	}
 }
 
 public typealias WorkspaceWillDeleteFilesResponse = WorkspaceEdit?

--- a/Sources/LanguageServerProtocol/Workspace/WillRenameFiles.swift
+++ b/Sources/LanguageServerProtocol/Workspace/WillRenameFiles.swift
@@ -1,21 +1,21 @@
 import Foundation
 
 public struct RenameFilesParams: Codable, Hashable, Sendable {
-    public var files: [FileRename]
+	public var files: [FileRename]
 
-    public init(files: [FileRename]) {
-        self.files = files
-    }
+	public init(files: [FileRename]) {
+		self.files = files
+	}
 }
 
 public struct FileRename: Codable, Hashable, Sendable {
-    public var oldUri: String
-    public var newUri: String
+	public var oldUri: String
+	public var newUri: String
 
-    public init(oldUri: String, newUri: String) {
-        self.oldUri = oldUri
-        self.newUri = newUri
-    }
+	public init(oldUri: String, newUri: String) {
+		self.oldUri = oldUri
+		self.newUri = newUri
+	}
 }
 
 public typealias WorkspaceWillRenameFilesResponse = WorkspaceEdit?


### PR DESCRIPTION
Add a swift-format file and apply whitespace formatting using the swift-format tool.

It does however also reformat some other things, eg breaking up long lines. Not sure what you think of this, maybe it is ok to have mixed whitespace, as you already mention in the existing readme (?)

This depends on #9 to be merged first, changes included here to avoid conflicts.