### PR TITLE
make window capabilities optional

### DIFF
--- a/Sources/LanguageServerProtocol/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ClientCapabilities.swift
@@ -60,28 +60,29 @@ public struct ShowDocumentClientCapabilities: Hashable, Codable, Sendable {
 
 public struct ShowMessageRequestClientCapabilities: Hashable, Codable, Sendable {
 	public struct MessageActionItemCapabilities: Hashable, Codable, Sendable {
-		public var additionalPropertiesSupport: Bool
+		public var additionalPropertiesSupport: Bool?
 
-		public init(additionalPropertiesSupport: Bool) {
+		public init(additionalPropertiesSupport: Bool?) {
 			self.additionalPropertiesSupport = additionalPropertiesSupport
 		}
 	}
 
-	public var messageActionItem: MessageActionItemCapabilities
+	public var messageActionItem: MessageActionItemCapabilities?
 
-	public init(messageActionItem: MessageActionItemCapabilities) {
+	public init(messageActionItem: MessageActionItemCapabilities?) {
 		self.messageActionItem = messageActionItem
 	}
 }
 
 public struct WindowClientCapabilities: Hashable, Codable, Sendable {
-	public var workDoneProgress: Bool
-	public var showMessage: ShowMessageRequestClientCapabilities
-	public var showDocument: ShowDocumentClientCapabilities
+	public var workDoneProgress: Bool?
+	public var showMessage: ShowMessageRequestClientCapabilities?
+	public var showDocument: ShowDocumentClientCapabilities?
 
 	public init(
-		workDoneProgress: Bool, showMessage: ShowMessageRequestClientCapabilities,
-		showDocument: ShowDocumentClientCapabilities
+		workDoneProgress: Bool,
+		showMessage: ShowMessageRequestClientCapabilities?,
+		showDocument: ShowDocumentClientCapabilities?
 	) {
 		self.workDoneProgress = workDoneProgress
 		self.showMessage = showMessage


### PR DESCRIPTION
At first, I got an error when trying to use the server with the Zed editor:
```
error: keyNotFound(CodingKeys(stringValue: "messageActionItem", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "params", intValue: nil), CodingKeys(stringValue: "capabilities", intValue: nil), CodingKeys(stringValue: "window", intValue: nil), CodingKeys(stringValue: "showMessage", intValue: nil)], debugDescription: "No value associated with key CodingKeys(stringValue: \"messageActionItem\", intValue: nil) (\"messageActionItem\").", underlyingError: nil))
```

Then I checked the specification and discovered differences in optionality:


1.
> workDoneProgress?: boolean;

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#serverInitiatedProgress

2.
> property path (optional): window.showMessage
> messageActionItem?: {
> additionalPropertiesSupport?: boolean;

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessageRequest

3.
> property path (optional): window.showDocument

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument