### PR TITLE
Add missing public initializers for LSP entities

### DIFF
--- a/Sources/LanguageServerProtocol/BaseProtocol.swift
+++ b/Sources/LanguageServerProtocol/BaseProtocol.swift
@@ -24,11 +24,21 @@ public struct CancelParams: Hashable, Codable, Sendable {
 public struct ProgressParams: Hashable, Codable, Sendable {
 	public var token: ProgressToken
 	public var value: LSPAny?
+
+	public init(token: ProgressToken, value: LSPAny? = nil) {
+		self.token = token
+		self.value = value
+	}
 }
 
 public struct LogTraceParams: Hashable, Codable, Sendable {
 	public var string: String
 	public var verbose: String?
+
+	public init(string: String, verbose: String? = nil) {
+		self.string = string
+		self.verbose = verbose
+	}
 }
 
 public enum TraceValue: String, Hashable, Codable, Sendable {

--- a/Sources/LanguageServerProtocol/BasicStructures.swift
+++ b/Sources/LanguageServerProtocol/BasicStructures.swift
@@ -136,6 +136,12 @@ public struct Command: Codable, Hashable, Sendable {
 	public let title: String
 	public let command: String
 	public let arguments: [LSPAny]?
+
+	public init(title: String, command: String, arguments: [LSPAny]? = nil) {
+		self.title = title
+		self.command = command
+		self.arguments = arguments
+	}
 }
 
 public enum SymbolKind: Int, CaseIterable, Hashable, Codable, Sendable {
@@ -191,6 +197,11 @@ public struct TextDocumentPositionParams: Codable, Hashable, Sendable {
 public struct LanguageStringPair: Codable, Hashable, Sendable {
 	public let language: LanguageIdentifier
 	public let value: String
+
+	public init(language: LanguageIdentifier, value: String) {
+		self.language = language
+		self.value = value
+	}
 }
 
 public typealias MarkedString = TwoTypeOption<String, LanguageStringPair>
@@ -209,6 +220,11 @@ extension MarkedString {
 public struct MarkupContent: Codable, Hashable, Sendable {
 	public let kind: MarkupKind
 	public let value: String
+
+	public init(kind: MarkupKind, value: String) {
+		self.kind = kind
+		self.value = value
+	}
 }
 
 public struct LocationLink: Codable, Hashable, Sendable {

--- a/Sources/LanguageServerProtocol/Client/JSONRPCServerConnection.swift
+++ b/Sources/LanguageServerProtocol/Client/JSONRPCServerConnection.swift
@@ -353,7 +353,7 @@ public actor JSONRPCServerConnection: ServerConnection {
 			case .custom:
 				let params = try decodeRequestParams(LSPAny.self, from: data)
 				let reqHandler: ServerRequest.Handler<LSPAny> = makeHandler(handler)
-				
+
 				yield(id: id, request: ServerRequest.custom(methodName, params, reqHandler))
 
 			}

--- a/Sources/LanguageServerProtocol/Client/ServerConnection.swift
+++ b/Sources/LanguageServerProtocol/Client/ServerConnection.swift
@@ -231,9 +231,9 @@ extension ServerConnection {
 		try await sendRequest(.completion(params, ClientRequest.NullHandler))
 	}
 
-    public func completeItemResolve(_ params: CompletionItem) async throws -> CompletionItem {
-        try await sendRequest(.completionItemResolve(params, ClientRequest.NullHandler))
-    }
+	public func completeItemResolve(_ params: CompletionItem) async throws -> CompletionItem {
+		try await sendRequest(.completionItemResolve(params, ClientRequest.NullHandler))
+	}
 
 	@available(*, deprecated, renamed: "hover(_:)")
 	public func hover(params: TextDocumentPositionParams) async throws -> HoverResponse {
@@ -263,7 +263,8 @@ extension ServerConnection {
 		try await declaration(params)
 	}
 
-	public func declaration(_ params: TextDocumentPositionParams) async throws -> DeclarationResponse
+	public func declaration(_ params: TextDocumentPositionParams) async throws
+		-> DeclarationResponse
 	{
 		try await sendRequest(.declaration(params, ClientRequest.NullHandler))
 	}
@@ -273,7 +274,8 @@ extension ServerConnection {
 		try await definition(params)
 	}
 
-	public func definition(_ params: TextDocumentPositionParams) async throws -> DefinitionResponse {
+	public func definition(_ params: TextDocumentPositionParams) async throws -> DefinitionResponse
+	{
 		try await sendRequest(.definition(params, ClientRequest.NullHandler))
 	}
 
@@ -309,7 +311,8 @@ extension ServerConnection {
 		try await documentSymbol(params)
 	}
 
-	public func documentSymbol(_ params: DocumentSymbolParams) async throws -> DocumentSymbolResponse
+	public func documentSymbol(_ params: DocumentSymbolParams) async throws
+		-> DocumentSymbolResponse
 	{
 		try await sendRequest(.documentSymbol(params, ClientRequest.NullHandler))
 	}
@@ -557,7 +560,8 @@ extension ServerConnection {
 		try await executeCommand(params)
 	}
 
-	public func executeCommand(_ params: ExecuteCommandParams) async throws -> ExecuteCommandResponse
+	public func executeCommand(_ params: ExecuteCommandParams) async throws
+		-> ExecuteCommandResponse
 	{
 		try await sendRequest(.workspaceExecuteCommand(params, ClientRequest.NullHandler))
 	}
@@ -659,7 +663,8 @@ extension ServerConnection {
 		try await selectionRange(params)
 	}
 
-	public func selectionRange(_ params: SelectionRangeParams) async throws -> SelectionRangeResponse
+	public func selectionRange(_ params: SelectionRangeParams) async throws
+		-> SelectionRangeResponse
 	{
 		try await sendRequest(.selectionRange(params, ClientRequest.NullHandler))
 	}
@@ -722,11 +727,14 @@ extension ServerConnection {
 		try await sendRequest(.inlayHintResolve(params, ClientRequest.NullHandler))
 	}
 
-	public func typeHierarchySubtypes(_ params: TypeHierarchySubtypesParams) async throws -> TypeHierarchySubtypesResponse {
+	public func typeHierarchySubtypes(_ params: TypeHierarchySubtypesParams) async throws
+		-> TypeHierarchySubtypesResponse
+	{
 		try await sendRequest(.typeHierarchySubtypes(params, ClientRequest.NullHandler))
 	}
 
-	public func typeHierarchySupertypes(_ params: TypeHierarchySupertypesParams) async throws -> TypeHierarchySupertypesResponse
+	public func typeHierarchySupertypes(_ params: TypeHierarchySupertypesParams) async throws
+		-> TypeHierarchySupertypesResponse
 	{
 		try await sendRequest(.typeHierarchySupertypes(params, ClientRequest.NullHandler))
 	}

--- a/Sources/LanguageServerProtocol/LanguageFeatures/CallHeirarchy.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/CallHeirarchy.swift
@@ -74,6 +74,13 @@ public struct CallHierarchyIncomingCallsParams: Codable, Hashable, Sendable {
 public struct CallHierarchyIncomingCall: Codable, Hashable, Sendable {
 	public let from: CallHierarchyItem
 	public let fromRanges: [LSPRange]
+
+	public init(
+		from: CallHierarchyItem, fromRanges: [LSPRange]
+	) {
+		self.from = from
+		self.fromRanges = fromRanges
+	}
 }
 
 public typealias CallHierarchyIncomingCallsResponse = [CallHierarchyIncomingCall]?
@@ -83,6 +90,11 @@ public typealias CallHierarchyOutgoingCallsParams = CallHierarchyIncomingCallsPa
 public struct CallHierarchyOutgoingCall: Codable, Hashable, Sendable {
 	public let to: CallHierarchyItem
 	public let fromRanges: [LSPRange]
+
+	public init(to: CallHierarchyItem, fromRanges: [LSPRange]) {
+		self.to = to
+		self.fromRanges = fromRanges
+	}
 }
 
 public typealias CallHierarchyOutgoingCallsResponse = [CallHierarchyOutgoingCall]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/CodeLens.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/CodeLens.swift
@@ -13,12 +13,26 @@ public struct CodeLensWorkspaceClientCapabilities: Codable, Hashable, Sendable {
 public struct CodeLensOptions: Codable, Hashable, Sendable {
 	public var workDoneProgress: Bool?
 	public var resolveProvider: Bool?
+
+	public init(workDoneProgress: Bool? = nil, resolveProvider: Bool? = nil) {
+		self.workDoneProgress = workDoneProgress
+		self.resolveProvider = resolveProvider
+	}
 }
 
 public struct CodeLensRegistrationOptions: Codable, Hashable, Sendable {
 	public var documentSelector: DocumentSelector?
 	public var workDoneProgress: Bool?
 	public var resolveProvider: Bool?
+
+	public init(
+		documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil,
+		resolveProvider: Bool? = nil
+	) {
+		self.documentSelector = documentSelector
+		self.workDoneProgress = workDoneProgress
+		self.resolveProvider = resolveProvider
+	}
 }
 
 public struct CodeLensParams: Codable, Hashable, Sendable {
@@ -40,6 +54,12 @@ public struct CodeLens: Codable, Hashable, Sendable {
 	public var range: LSPRange
 	public var command: Command?
 	public var data: LSPAny?
+
+	public init(range: LSPRange, command: Command? = nil, data: LSPAny? = nil) {
+		self.range = range
+		self.command = command
+		self.data = data
+	}
 }
 
 public typealias CodeLensResponse = [CodeLens]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/ColorPresentation.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/ColorPresentation.swift
@@ -23,6 +23,14 @@ public struct ColorPresentation: Codable, Hashable, Sendable {
 	public let label: String
 	public let textEdit: TextEdit?
 	public let additionalTextEdits: [TextEdit]?
+
+	public init(
+		label: String, textEdit: TextEdit? = nil, additionalTextEdits: [TextEdit]? = nil
+	) {
+		self.label = label
+		self.textEdit = textEdit
+		self.additionalTextEdits = additionalTextEdits
+	}
 }
 
 public typealias ColorPresentationResponse = [ColorPresentation]

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Completion.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Completion.swift
@@ -243,6 +243,16 @@ public struct CompletionRegistrationOptions: Codable {
 	public let documentSelector: DocumentSelector?
 	public let triggerCharacters: [String]?
 	public let resolveProvider: Bool?
+
+	public init(
+		documentSelector: DocumentSelector? = nil,
+		triggerCharacters: [String]? = nil,
+		resolveProvider: Bool? = nil
+	) {
+		self.documentSelector = documentSelector
+		self.triggerCharacters = triggerCharacters
+		self.resolveProvider = resolveProvider
+	}
 }
 
 public enum InsertTextMode: Int, CaseIterable, Codable, Hashable, Sendable {

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentColor.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentColor.swift
@@ -22,11 +22,23 @@ public struct Color: Codable, Hashable, Sendable {
 	public let green: Float
 	public let blue: Float
 	public let alpha: Float
+
+	public init(red: Float, green: Float, blue: Float, alpha: Float) {
+		self.red = red
+		self.green = green
+		self.blue = blue
+		self.alpha = alpha
+	}
 }
 
 public struct ColorInformation: Codable, Hashable, Sendable {
 	public let range: LSPRange
 	public let color: Color
+
+	public init(range: LSPRange, color: Color) {
+		self.range = range
+		self.color = color
+	}
 }
 
 public typealias DocumentColorResponse = [ColorInformation]

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentHighlight.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentHighlight.swift
@@ -7,6 +7,13 @@ public typealias DocumentHighlightOptions = WorkDoneProgressOptions
 public struct DocumentHighlightRegistrationOptions: Codable, Hashable, Sendable {
 	public var documentSelector: DocumentSelector?
 	public var workDoneProgress: Bool?
+
+	public init(
+		documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil
+	) {
+		self.documentSelector = documentSelector
+		self.workDoneProgress = workDoneProgress
+	}
 }
 
 public struct DocumentHighlightParams: Codable, Hashable, Sendable {
@@ -35,6 +42,13 @@ public enum DocumentHighlightKind: Int, CaseIterable, Codable, Hashable, Sendabl
 public struct DocumentHighlight: Codable, Hashable, Sendable {
 	public var range: LSPRange
 	public var kind: DocumentHighlightKind?
+
+	public init(
+		range: LSPRange, kind: DocumentHighlightKind? = nil
+	) {
+		self.range = range
+		self.kind = kind
+	}
 }
 
 public typealias DocumentHighlightResponse = [DocumentHighlight]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentLink.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentLink.swift
@@ -20,6 +20,11 @@ public struct DocumentLinkClientCapabilities: Codable, Hashable, Sendable {
 public struct DocumentLinkOptions: Codable, Hashable, Sendable {
 	public var workDoneProgress: Bool?
 	public var resolveProvider: Bool?
+
+	public init(workDoneProgress: Bool? = nil, resolveProvider: Bool? = nil) {
+		self.workDoneProgress = workDoneProgress
+		self.resolveProvider = resolveProvider
+	}
 }
 
 public struct DocumentLinkRegistrationOptions: Codable, Hashable, Sendable {
@@ -40,6 +45,13 @@ public struct DocumentLinkRegistrationOptions: Codable, Hashable, Sendable {
 public struct DocumentLinkParams: Codable, Hashable, Sendable {
 	public var workDoneToken: ProgressToken?
 	public var partialResultToken: ProgressToken?
+
+	public init(
+		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil
+	) {
+		self.workDoneToken = workDoneToken
+		self.partialResultToken = partialResultToken
+	}
 }
 
 public struct DocumentLink: Codable, Hashable, Sendable {

--- a/Sources/LanguageServerProtocol/LanguageFeatures/FoldingRange.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/FoldingRange.swift
@@ -34,6 +34,17 @@ public struct FoldingRange: Codable, Hashable, Sendable {
 	public let endLine: Int
 	public let endCharacter: Int?
 	public let kind: FoldingRangeKind?
+
+	public init(
+		startLine: Int, startCharacter: Int? = nil, endLine: Int,
+		endCharacter: Int? = nil, kind: FoldingRangeKind? = nil
+	) {
+		self.startLine = startLine
+		self.startCharacter = startCharacter
+		self.endLine = endLine
+		self.endCharacter = endCharacter
+		self.kind = kind
+	}
 }
 
 public typealias FoldingRangeResponse = [FoldingRange]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Rename.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Rename.swift
@@ -25,6 +25,11 @@ public struct RenameClientCapabilities: Codable, Hashable, Sendable {
 public struct RenameOptions: Codable, Hashable, Sendable {
 	public var workDoneProgress: Bool?
 	public var prepareProvider: Bool?
+
+	public init(workDoneProgress: Bool? = nil, prepareProvider: Bool? = nil) {
+		self.workDoneProgress = workDoneProgress
+		self.prepareProvider = prepareProvider
+	}
 }
 
 public typealias PrepareRenameParams = TextDocumentPositionParams
@@ -44,10 +49,19 @@ public struct RenameParams: Codable, Hashable, Sendable {
 public struct RangeWithPlaceholder: Codable, Hashable, Sendable {
 	public let range: LSPRange
 	public let placeholder: String
+
+	public init(range: LSPRange, placeholder: String) {
+		self.range = range
+		self.placeholder = placeholder
+	}
 }
 
 public struct PrepareRenameDefaultBehavior: Codable, Hashable, Sendable {
 	public let defaultBehavior: Bool
+
+	public init(defaultBehavior: Bool) {
+		self.defaultBehavior = defaultBehavior
+	}
 }
 
 public typealias PrepareRenameResponse = ThreeTypeOption<

--- a/Sources/LanguageServerProtocol/LanguageFeatures/SelectionRange.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/SelectionRange.swift
@@ -27,6 +27,11 @@ public struct SelectionRangeParams: Codable, Hashable, Sendable {
 public final class SelectionRange: Codable, Sendable {
 	public let range: LSPRange
 	public let parent: SelectionRange?
+
+	public init(range: LSPRange, parent: SelectionRange?) {
+		self.range = range
+		self.parent = parent
+	}
 }
 
 extension SelectionRange: Equatable {

--- a/Sources/LanguageServerProtocol/LanguageFeatures/SignatureHelp.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/SignatureHelp.swift
@@ -53,7 +53,10 @@ public struct ParameterInformation: Codable, Hashable, Sendable {
 	public var label: TwoTypeOption<String, [UInt]>
 	public var documentation: TwoTypeOption<String, MarkupContent>?
 
-	public init(label: TwoTypeOption<String, [UInt]>, documentation: TwoTypeOption<String, MarkupContent>? = nil) {
+	public init(
+		label: TwoTypeOption<String, [UInt]>,
+		documentation: TwoTypeOption<String, MarkupContent>? = nil
+	) {
 		self.label = label
 		self.documentation = documentation
 	}

--- a/Sources/LanguageServerProtocol/LanguageFeatures/SignatureHelp.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/SignatureHelp.swift
@@ -52,6 +52,11 @@ public struct SignatureHelpClientCapabilities: Codable, Hashable, Sendable {
 public struct ParameterInformation: Codable, Hashable, Sendable {
 	public var label: TwoTypeOption<String, [UInt]>
 	public var documentation: TwoTypeOption<String, MarkupContent>?
+
+	public init(label: TwoTypeOption<String, [UInt]>, documentation: TwoTypeOption<String, MarkupContent>? = nil) {
+		self.label = label
+		self.documentation = documentation
+	}
 }
 
 public struct SignatureInformation: Codable, Hashable, Sendable {
@@ -59,17 +64,43 @@ public struct SignatureInformation: Codable, Hashable, Sendable {
 	public var documentation: TwoTypeOption<String, MarkupContent>?
 	public var parameters: [ParameterInformation]?
 	public var activeParameter: UInt?
+
+	public init(
+		label: String, documentation: TwoTypeOption<String, MarkupContent>? = nil,
+		parameters: [ParameterInformation]? = nil, activeParameter: UInt? = nil
+	) {
+		self.label = label
+		self.documentation = documentation
+		self.parameters = parameters
+		self.activeParameter = activeParameter
+	}
 }
 
 public struct SignatureHelp: Codable, Hashable, Sendable {
 	public let signatures: [SignatureInformation]
 	public let activeSignature: Int?
 	public let activeParameter: Int?
+
+	public init(
+		signatures: [SignatureInformation], activeSignature: Int? = nil, activeParameter: Int? = nil
+	) {
+		self.signatures = signatures
+		self.activeSignature = activeSignature
+		self.activeParameter = activeParameter
+	}
 }
 
 public struct SignatureHelpRegistrationOptions: Codable, Hashable, Sendable {
 	public let documentSelector: DocumentSelector?
 	public let triggerCharacters: [String]?
+
+	public init(
+		documentSelector: DocumentSelector? = nil,
+		triggerCharacters: [String]? = nil
+	) {
+		self.documentSelector = documentSelector
+		self.triggerCharacters = triggerCharacters
+	}
 }
 
 public typealias SignatureHelpResponse = SignatureHelp?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/TypeHeirarchy.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/TypeHeirarchy.swift
@@ -72,7 +72,10 @@ public struct TypeHierarchySubtypesParams: Codable, Hashable, Sendable {
 	public let partialResultToken: ProgressToken?
 	public let item: TypeHierarchyItem
 
-	public init(workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil, item: TypeHierarchyItem) {
+	public init(
+		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil,
+		item: TypeHierarchyItem
+	) {
 		self.workDoneToken = workDoneToken
 		self.partialResultToken = partialResultToken
 		self.item = item

--- a/Sources/LanguageServerProtocol/LanguageFeatures/TypeHeirarchy.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/TypeHeirarchy.swift
@@ -6,6 +6,16 @@ public struct TypeHierarchyRegistrationOptions: Codable, Hashable, Sendable {
 	public let textDocument: TextDocumentIdentifier
 	public let position: Position
 	public let workDoneToken: ProgressToken?
+
+	public init(
+		textDocument: TextDocumentIdentifier,
+		position: Position,
+		workDoneToken: ProgressToken? = nil
+	) {
+		self.textDocument = textDocument
+		self.position = position
+		self.workDoneToken = workDoneToken
+	}
 }
 
 public struct TypeHierarchyPrepareParams: Codable, Hashable, Sendable {

--- a/Sources/LanguageServerProtocol/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ServerCapabilities.swift
@@ -8,6 +8,20 @@ public struct StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions:
 	public var position: Position
 	public var documentSelector: DocumentSelector?
 	public var id: String?
+
+	public init(
+		workDoneProgress: Bool? = nil,
+	 	textDocument: TextDocumentIdentifier,
+		position: Position,
+		documentSelector: DocumentSelector? = nil,
+	 	id: String? = nil
+	) {
+		self.workDoneProgress = workDoneProgress
+		self.textDocument = textDocument
+		self.position = position
+		self.documentSelector = documentSelector
+		self.id = id
+	}
 }
 
 public struct PartialResultsWorkDoneProgressTextDocumentRegistrationOptions: Codable, Hashable,
@@ -18,14 +32,36 @@ public struct PartialResultsWorkDoneProgressTextDocumentRegistrationOptions: Cod
 	public var position: Position
 	public var documentSelector: DocumentSelector?
 	public var partialResultToken: ProgressToken?
+
+	public init(
+		workDoneProgress: Bool? = nil,
+		textDocument: TextDocumentIdentifier,
+		position: Position,
+		documentSelector: DocumentSelector? = nil,
+		partialResultToken: ProgressToken? = nil
+	) {
+		self.workDoneProgress = workDoneProgress
+		self.textDocument = textDocument
+		self.position = position
+		self.documentSelector = documentSelector
+		self.partialResultToken = partialResultToken
+	}
 }
 
 public struct WorkDoneProgressOptions: Codable, Hashable, Sendable {
 	public var workDoneProgress: Bool?
+
+	public init(workDoneProgress: Bool? = nil) {
+		self.workDoneProgress = workDoneProgress
+	}
 }
 
 public struct SaveOptions: Codable, Hashable, Sendable {
 	public let includeText: Bool?
+
+	public init(includeText: Bool? = nil) {
+		self.includeText = includeText
+	}
 }
 
 public enum TextDocumentSyncKind: Int, Codable, Hashable, Sendable {
@@ -101,6 +137,16 @@ public struct SignatureHelpOptions: Codable, Hashable, Sendable {
 	public var workDoneProgress: Bool?
 	public var triggerCharacters: [String]?
 	public var retriggerCharacters: [String]?
+
+	public init(
+		workDoneProgress: Bool? = nil,
+	 	triggerCharacters: [String]? = nil,
+		retriggerCharacters: [String]? = nil
+	) {
+		self.workDoneProgress = workDoneProgress
+		self.triggerCharacters = triggerCharacters
+		self.retriggerCharacters = retriggerCharacters
+	}
 }
 
 public typealias DeclarationOptions = WorkDoneProgressOptions
@@ -125,6 +171,11 @@ public typealias ReferenceOptions = WorkDoneProgressOptions
 public struct DocumentSymbolOptions: Codable, Hashable, Sendable {
 	public var workDoneProgress: Bool?
 	public var label: String?
+
+	public init(workDoneProgress: Bool? = nil, label: String? = nil) {
+		self.workDoneProgress = workDoneProgress
+		self.label = label
+	}
 }
 
 public typealias DocumentColorOptions = WorkDoneProgressOptions
@@ -139,6 +190,14 @@ public typealias DocumentRangeFormattingOptions = WorkDoneProgressOptions
 public struct DocumentOnTypeFormattingOptions: Codable, Hashable, Sendable {
 	public var firstTriggerCharacter: String
 	public var moreTriggerCharacter: [String]?
+
+	public init(
+		firstTriggerCharacter: String,
+		moreTriggerCharacter: [String]? = nil
+	) {
+		self.firstTriggerCharacter = firstTriggerCharacter
+		self.moreTriggerCharacter = moreTriggerCharacter
+	}
 }
 
 public typealias FoldingRangeOptions = WorkDoneProgressOptions
@@ -167,7 +226,6 @@ public struct SemanticTokensOptions: Codable, Hashable, Sendable {
 		self.range = range
 		self.full = full
 	}
-
 }
 
 public struct SemanticTokensRegistrationOptions: Codable, Hashable, Sendable {
@@ -201,6 +259,14 @@ public typealias MonikerRegistrationOptions =
 public struct WorkspaceFoldersServerCapabilities: Codable, Hashable, Sendable {
 	public var supported: Bool?
 	public var changeNotifications: TwoTypeOption<String, Bool>?
+
+	public init(
+		supported: Bool? = nil,
+		changeNotifications: TwoTypeOption<String, Bool>? = nil
+	) {
+		self.supported = supported
+		self.changeNotifications = changeNotifications
+	}
 }
 
 public struct ServerCapabilities: Codable, Hashable, Sendable {

--- a/Sources/LanguageServerProtocol/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ServerCapabilities.swift
@@ -11,10 +11,10 @@ public struct StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions:
 
 	public init(
 		workDoneProgress: Bool? = nil,
-	 	textDocument: TextDocumentIdentifier,
+		textDocument: TextDocumentIdentifier,
 		position: Position,
 		documentSelector: DocumentSelector? = nil,
-	 	id: String? = nil
+		id: String? = nil
 	) {
 		self.workDoneProgress = workDoneProgress
 		self.textDocument = textDocument
@@ -140,7 +140,7 @@ public struct SignatureHelpOptions: Codable, Hashable, Sendable {
 
 	public init(
 		workDoneProgress: Bool? = nil,
-	 	triggerCharacters: [String]? = nil,
+		triggerCharacters: [String]? = nil,
 		retriggerCharacters: [String]? = nil
 	) {
 		self.workDoneProgress = workDoneProgress
@@ -343,7 +343,8 @@ public struct ServerCapabilities: Codable, Hashable, Sendable {
 	public var semanticTokensProvider:
 		TwoTypeOption<SemanticTokensOptions, SemanticTokensRegistrationOptions>?
 	public var monikerProvider: ThreeTypeOption<Bool, MonikerOptions, MonikerRegistrationOptions>?
-	public var typeHierarchyProvider: ThreeTypeOption<Bool, TypeHierarchyOptions, TypeHierarchyRegistrationOptions>?
+	public var typeHierarchyProvider:
+		ThreeTypeOption<Bool, TypeHierarchyOptions, TypeHierarchyRegistrationOptions>?
 	public var inlayHintProvider:
 		ThreeTypeOption<Bool, InlayHintOptions, InlayHintRegistrationOptions>?
 	public var diagnosticProvider: TwoTypeOption<DiagnosticOptions, DiagnosticRegistrationOptions>?

--- a/Sources/LanguageServerProtocol/TextSynchronization.swift
+++ b/Sources/LanguageServerProtocol/TextSynchronization.swift
@@ -122,11 +122,11 @@ public typealias WillSaveWaitUntilResponse = [TextEdit]?
 ///
 /// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#insertReplaceEdit
 public struct InsertReplaceEdit: Codable, Hashable, Sendable {
-    public let newText: String
-    public let insert: LSPRange
-    public let replace: LSPRange
+	public let newText: String
+	public let insert: LSPRange
+	public let replace: LSPRange
 
-    public init(newText: String, insert: LSPRange, replace: LSPRange) {
+	public init(newText: String, insert: LSPRange, replace: LSPRange) {
 		self.newText = newText
 		self.insert = insert
 		self.replace = replace

--- a/Sources/LanguageServerProtocol/TextSynchronization.swift
+++ b/Sources/LanguageServerProtocol/TextSynchronization.swift
@@ -46,6 +46,14 @@ public struct DidChangeTextDocumentParams: Codable, Hashable, Sendable {
 public struct TextDocumentChangeRegistrationOptions: Codable, Hashable, Sendable {
 	public let documentSelector: DocumentSelector?
 	public let syncKind: TextDocumentSyncKind
+
+	public init(
+		documentSelector: DocumentSelector?,
+		syncKind: TextDocumentSyncKind
+	) {
+		self.documentSelector = documentSelector
+		self.syncKind = syncKind
+	}
 }
 
 public struct DidSaveTextDocumentParams: Codable, Hashable, Sendable {
@@ -68,6 +76,14 @@ public struct DidSaveTextDocumentParams: Codable, Hashable, Sendable {
 public struct TextDocumentSaveRegistrationOptions: Codable, Hashable, Sendable {
 	public let documentSelector: DocumentSelector?
 	public let includeText: Bool?
+
+	public init(
+		documentSelector: DocumentSelector?,
+		includeText: Bool? = nil
+	) {
+		self.documentSelector = documentSelector
+		self.includeText = includeText
+	}
 }
 
 public struct DidCloseTextDocumentParams: Codable, Hashable, Sendable {
@@ -109,6 +125,12 @@ public struct InsertReplaceEdit: Codable, Hashable, Sendable {
     public let newText: String
     public let insert: LSPRange
     public let replace: LSPRange
+
+    public init(newText: String, insert: LSPRange, replace: LSPRange) {
+		self.newText = newText
+		self.insert = insert
+		self.replace = replace
+	}
 }
 
 public struct TextEdit: Codable, Hashable, Sendable {

--- a/Sources/LanguageServerProtocol/Window/ShowMessageRequest.swift
+++ b/Sources/LanguageServerProtocol/Window/ShowMessageRequest.swift
@@ -2,12 +2,22 @@ import Foundation
 
 public struct MessageActionItem: Codable, Hashable, Sendable {
 	public var title: String
+
+	public init(title: String) {
+		self.title = title
+	}
 }
 
 public struct ShowMessageRequestParams: Codable, Hashable, Sendable {
 	public var type: MessageType
 	public var message: String
 	public var actions: [MessageActionItem]?
+
+	public init(type: MessageType, message: String, actions: [MessageActionItem]? = nil) {
+		self.type = type
+		self.message = message
+		self.actions = actions
+	}
 }
 
 extension ShowMessageRequestParams: CustomStringConvertible {

--- a/Sources/LanguageServerProtocol/Workspace.swift
+++ b/Sources/LanguageServerProtocol/Workspace.swift
@@ -142,7 +142,8 @@ public struct RenameFile: Codable, Hashable, Sendable {
 	public let newUri: DocumentUri
 	public let options: RenameFileOptions
 
-	public init(kind: String, oldUri: DocumentUri, newUri: DocumentUri, options: RenameFileOptions) {
+	public init(kind: String, oldUri: DocumentUri, newUri: DocumentUri, options: RenameFileOptions)
+	{
 		self.kind = kind
 		self.oldUri = oldUri
 		self.newUri = newUri
@@ -223,7 +224,9 @@ public struct WorkspaceEdit: Codable, Hashable, Sendable {
 	public let changes: [DocumentUri: [TextEdit]]?
 	public let documentChanges: [WorkspaceEditDocumentChange]?
 
-	public init(changes: [DocumentUri: [TextEdit]]?, documentChanges: [WorkspaceEditDocumentChange]?) {
+	public init(
+		changes: [DocumentUri: [TextEdit]]?, documentChanges: [WorkspaceEditDocumentChange]?
+	) {
 		self.changes = changes
 		self.documentChanges = documentChanges
 	}

--- a/Sources/LanguageServerProtocol/Workspace/Symbol.swift
+++ b/Sources/LanguageServerProtocol/Workspace/Symbol.swift
@@ -35,6 +35,11 @@ public struct WorkspaceSymbolClientCapabilities: Codable, Hashable, Sendable {
 public struct WorkspaceSymbolOptions: Codable, Hashable, Sendable {
 	public var workDoneProgress: Bool?
 	public var resolveProvider: Bool?
+
+	public init(workDoneProgress: Bool? = nil, resolveProvider: Bool? = nil) {
+		self.workDoneProgress = workDoneProgress
+		self.resolveProvider = resolveProvider
+	}
 }
 
 public typealias WorkspaceSymbolRegistrationOptions = WorkspaceSymbolOptions
@@ -59,6 +64,18 @@ public struct WorkspaceSymbol: Codable, Hashable, Sendable {
 	public var tags: [SymbolTag]?
 	public var location: TwoTypeOption<Location, TextDocumentIdentifier>?
 	public var containerName: String?
+
+	public init(
+		name: String, kind: SymbolKind, tags: [SymbolTag]? = nil,
+		location: TwoTypeOption<Location, TextDocumentIdentifier>? = nil,
+		containerName: String? = nil
+	) {
+		self.name = name
+		self.kind = kind
+		self.tags = tags
+		self.location = location
+		self.containerName = containerName
+	}
 }
 
 public typealias WorkspaceSymbolResponse = TwoTypeOption<[SymbolInformation], [WorkspaceSymbol]>?

--- a/Sources/LanguageServerProtocol/Workspace/WillDeleteFiles.swift
+++ b/Sources/LanguageServerProtocol/Workspace/WillDeleteFiles.swift
@@ -2,6 +2,10 @@ import Foundation
 
 public struct DeleteFilesParams: Codable, Hashable, Sendable {
 	public var files: [FileDelete]
+
+	public init(files: [FileDelete]) {
+		self.files = files
+	}
 }
 
 public struct FileDelete: Codable, Hashable, Sendable {


### PR DESCRIPTION
Hello! I noticed some issues with the library’s public API. I guess this is a consequence of the library’s past use in a mono-repo (with LanguageClient), and maybe also because some entities haven’t been used yet at all

Problem:

Some of public entities have `public let` properties and haven't `public init` constructors, that makes impossible to create and fill them outside library scope. 

Solution:

I have added initializers for all the public LSP protocol entities I found (even those with `var` properties).

P.S.

I also ran `./run-swift-format.sh` and added changes in second commit
