### PR TITLE
Make WorkspaceClientCapabilities.resourceOperations optional

### DIFF
--- a/Sources/LanguageServerProtocol/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ClientCapabilities.swift
@@ -33,11 +33,12 @@ public enum FailureHandlingKind: String, Codable, Hashable, Sendable {
 
 public struct WorkspaceClientCapabilityEdit: Codable, Hashable, Sendable {
 	public let documentChanges: Bool?
-	public let resourceOperations: [ResourceOperationKind]
+	public let resourceOperations: [ResourceOperationKind]?
 	public let failureHandling: FailureHandlingKind?
 
 	public init(
-		documentChanges: Bool?, resourceOperations: [ResourceOperationKind],
+		documentChanges: Bool?,
+		resourceOperations: [ResourceOperationKind]?,
 		failureHandling: FailureHandlingKind?
 	) {
 		self.documentChanges = documentChanges


### PR DESCRIPTION
According to spec:
https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/

WorkspaceClientCapabilities.resourceOperations is optional

Eglot (https://elpa.gnu.org/devel/eglot.html) does not send this field which results in error:

```
[jsonrpc] e[14:17:54.582] --> initialize[1]

{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "initialize",
  "params": {
    "capabilities": {
      "experimental": {},
      "general": {
        "positionEncodings": [
          "utf-32",
          "utf-8",
          "utf-16"
        ]
      },
      "textDocument": {
        "codeAction": {
          "codeActionLiteralSupport": {
            "codeActionKind": {
              "valueSet": [
                "quickfix",
                "refactor",
                "refactor.extract",
                "refactor.inline",
                "refactor.rewrite",
                "source",
                "source.organizeImports"
              ]
            }
          },
          "dataSupport": true,
          "dynamicRegistration": false,
          "isPreferredSupport": true,
          "resolveSupport": {
            "properties": [
              "edit",
              "command"
            ]
          }
        },
        "completion": {
          "completionItem": {
            "deprecatedSupport": true,
            "insertReplaceSupport": true,
            "resolveSupport": {
              "properties": [
                "documentation",
                "details",
                "additionalTextEdits"
              ]
            },
            "snippetSupport": true,
            "tagSupport": {
              "valueSet": [
                1
              ]
            }
          },
          "contextSupport": true,
          "dynamicRegistration": false
        },
        "declaration": {
          "dynamicRegistration": false,
          "linkSupport": true
        },
        "definition": {
          "dynamicRegistration": false,
          "linkSupport": true
        },
        "documentHighlight": {
          "dynamicRegistration": false
        },
        "documentSymbol": {
          "dynamicRegistration": false,
          "hierarchicalDocumentSymbolSupport": true,
          "symbolKind": {
            "valueSet": [
              1,
              2,
              3,
              4,
              5,
              6,
              7,
              8,
              9,
              10,
              11,
              12,
              13,
              14,
              15,
              16,
              17,
              18,
              19,
              20,
              21,
              22,
              23,
              24,
              25,
              26
            ]
          }
        },
        "formatting": {
          "dynamicRegistration": false
        },
        "hover": {
          "contentFormat": [
            "markdown",
            "plaintext"
          ],
          "dynamicRegistration": false
        },
        "implementation": {
          "dynamicRegistration": false,
          "linkSupport": true
        },
        "inlayHint": {
          "dynamicRegistration": false
        },
        "publishDiagnostics": {
          "codeDescriptionSupport": false,
          "relatedInformation": false,
          "tagSupport": {
            "valueSet": [
              1,
              2
            ]
          }
        },
        "rangeFormatting": {
          "dynamicRegistration": false
        },
        "references": {
          "dynamicRegistration": false
        },
        "rename": {
          "dynamicRegistration": false
        },
        "signatureHelp": {
          "dynamicRegistration": false,
          "signatureInformation": {
            "activeParameterSupport": true,
            "documentationFormat": [
              "markdown",
              "plaintext"
            ],
            "parameterInformation": {
              "labelOffsetSupport": true
            }
          }
        },
        "synchronization": {
          "didSave": true,
          "dynamicRegistration": false,
          "willSave": true,
          "willSaveWaitUntil": true
        },
        "typeDefinition": {
          "dynamicRegistration": false,
          "linkSupport": true
        }
      },
      "window": {
        "showDocument": {
          "support": true
        },
        "workDoneProgress": true
      },
      "workspace": {
        "applyEdit": true,
        "configuration": true,
        "didChangeWatchedFiles": {
          "dynamicRegistration": true
        },
        "executeCommand": {
          "dynamicRegistration": false
        },
        "symbol": {
          "dynamicRegistration": false
        },
        "workspaceEdit": {      <----------------------------------------- there is no resourceOperations
          "documentChanges": true
        },
        "workspaceFolders": true
      }
    },
    "clientInfo": {
      "name": "Eglot",
      "version": "1.18"
    },
    "initializationOptions": {},
    "processId": 92947,
    "rootPath": "<redacted>",
    "rootUri": "<redacted>",
    "workspaceFolders": [
      {
        "name": "<redacted>",
        "uri": "<redacted>"
      }
    ]
  }
}

[stderr]  2025-05-27T14:17:54+0300 info com.kattouf.package-swift-lsp : [PackageSwiftLSPLibrary] Starting server
[stderr]  2025-05-27T14:17:54+0300 error com.kattouf.package-swift-lsp : [PackageSwiftLSPLibrary] Received error: keyNotFound(CodingKeys(stringValue: "resourceOperations", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "params", intValue: nil), CodingKeys(stringValue: "capabilities", intValue: nil), CodingKeys(stringValue: "workspace", intValue: nil), CodingKeys(stringValue: "workspaceEdit", intValue: nil)], debugDescription: "No value associated with key CodingKeys(stringValue: \"resourceOperations\", intValue: nil) (\"resourceOperations\").", underlyingError: nil))
```