### PR TITLE
Conformance of SemanticToken to Codable, Hashable, and Sendable

### DIFF
--- a/Sources/LanguageServerProtocol/LanguageFeatures/SemanticTokens.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/SemanticTokens.swift
@@ -139,7 +139,7 @@ public struct SemanticTokensParams: Codable, Hashable, Sendable {
 }
 
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSelector
-public struct SemanticToken {
+public struct SemanticToken: Codable, Hashable, Sendable {
 	// typealias EncodedTuple = (line: UInt32, char: UInt32, length: UInt32, type: UInt32, modifiers: UInt32)
 
 	public let line: UInt32


### PR DESCRIPTION
The only one I really need is Sendable... But I figured to be consistent I'd include Codable and Hashable unless you have any objections.