### PR TITLE
Add API documentation

### DIFF
--- a/Sources/LanguageServerProtocol/Additions/Protocol+Mutating.swift
+++ b/Sources/LanguageServerProtocol/Additions/Protocol+Mutating.swift
@@ -1,12 +1,14 @@
 import Foundation
 
 extension ClientNotification {
+	/// Whether this notification mutates the server's state.
 	public var mutatesServerState: Bool {
 		return true
 	}
 }
 
 extension ClientRequest {
+	/// Whether this request mutates the server's state.
 	public var mutatesServerState: Bool {
 		switch self {
 		case .initialize:

--- a/Sources/LanguageServerProtocol/Additions/ServerCapabilities+Extensions.swift
+++ b/Sources/LanguageServerProtocol/Additions/ServerCapabilities+Extensions.swift
@@ -1,30 +1,36 @@
 import Foundation
 
 extension Registration {
+	/// The client request method this registration corresponds to, if any.
 	public var requestMethod: ClientRequest.Method? {
 		return ClientRequest.Method(rawValue: method)
 	}
 
+	/// The client notification method this registration corresponds to, if any.
 	public var notificationMethod: ClientNotification.Method? {
 		return ClientNotification.Method(rawValue: method)
 	}
 }
 
 extension Unregistration {
+	/// The client request method this unregistration corresponds to, if any.
 	public var requestMethod: ClientRequest.Method? {
 		return ClientRequest.Method(rawValue: method)
 	}
 
+	/// The client notification method this unregistration corresponds to, if any.
 	public var notificationMethod: ClientNotification.Method? {
 		return ClientNotification.Method(rawValue: method)
 	}
 }
 
 extension ServerCapabilities {
+	/// Applies multiple dynamic registrations to the server capabilities.
 	public mutating func applyRegistrations(_ registrations: [Registration]) throws {
 		try registrations.forEach({ try applyRegistration($0) })
 	}
 
+	/// Applies a single dynamic registration to the server capabilities.
 	public mutating func applyRegistration(_ registration: Registration) throws {
 		switch registration.requestMethod {
 		case .textDocumentSemanticTokens:
@@ -53,10 +59,12 @@ extension ServerCapabilities {
 		}
 	}
 
+	/// Applies multiple dynamic unregistrations to the server capabilities.
 	public mutating func applyUnregistrations(_ unregistrations: [Unregistration]) throws {
 		try unregistrations.forEach({ try applyUnregistration($0) })
 	}
 
+	/// Applies a single dynamic unregistration to the server capabilities.
 	public mutating func applyUnregistration(_ unregistration: Unregistration) throws {
 		switch unregistration.requestMethod {
 		case .textDocumentSemanticTokens:
@@ -79,6 +87,7 @@ extension ServerCapabilities {
 }
 
 extension TwoTypeOption where T == TextDocumentSyncOptions, U == TextDocumentSyncKind {
+	/// Returns effective text document sync options regardless of the option form.
 	public var effectiveOptions: TextDocumentSyncOptions {
 		switch self {
 		case .optionA(let value):
@@ -92,6 +101,7 @@ extension TwoTypeOption where T == TextDocumentSyncOptions, U == TextDocumentSyn
 }
 
 extension TwoTypeOption where T == SemanticTokensOptions, U == SemanticTokensRegistrationOptions {
+	/// Returns effective semantic tokens options regardless of the option form.
 	public var effectiveOptions: SemanticTokensOptions {
 		switch self {
 		case .optionA(let options):
@@ -107,6 +117,7 @@ extension TwoTypeOption where T == SemanticTokensOptions, U == SemanticTokensReg
 }
 
 extension SemanticTokensClientCapabilities.Requests.RangeOption {
+	/// Whether range requests are supported.
 	public var supported: Bool {
 		switch self {
 		case .optionA(let value):
@@ -118,6 +129,7 @@ extension SemanticTokensClientCapabilities.Requests.RangeOption {
 }
 
 extension SemanticTokensClientCapabilities.Requests.FullOption {
+	/// Whether full requests are supported.
 	public var supported: Bool {
 		switch self {
 		case .optionA(let value):
@@ -127,6 +139,7 @@ extension SemanticTokensClientCapabilities.Requests.FullOption {
 		}
 	}
 
+	/// Whether delta updates are supported for full requests.
 	public var deltaSupported: Bool {
 		switch self {
 		case .optionA(_):

--- a/Sources/LanguageServerProtocol/Additions/Snippet.swift
+++ b/Sources/LanguageServerProtocol/Additions/Snippet.swift
@@ -1,23 +1,34 @@
 import Foundation
 
+/// Represents an LSP snippet string and provides parsing utilities.
 public struct Snippet {
+	/// A parsed element of a snippet.
 	public enum Element: Equatable {
+		/// A plain text element.
 		case text(String)
+		/// A tabstop with the given index.
 		case tabstop(Int)
+		/// A placeholder with an index and default text.
 		case placeholder(Int, String)
+		/// A choice with an index and list of values.
 		case choice(Int, [String])
+		/// A variable with a name and default value.
 		case variable(String, String)
+		/// A variable with a transform (name, regex, format, options).
 		case variableTransform(String, String, String, String)
 	}
 
+	/// The raw snippet string value.
 	public let value: String
 
+	/// Creates a snippet from a raw string value.
 	public init(value: String) {
 		self.value = value
 	}
 }
 
 extension Snippet {
+	/// The ranges of snippet elements within the raw value.
 	public var elementRanges: [NSRange] {
 		let regex = try! NSRegularExpression(pattern: #"\$(\w+|\{([^$]+)\})"#)
 
@@ -52,6 +63,7 @@ extension Snippet {
 		}
 	}
 
+	/// All parsed snippet elements.
 	public var elements: [Snippet.Element] {
 		var list = [Snippet.Element]()
 

--- a/Sources/LanguageServerProtocol/Additions/TokenRepresentation.swift
+++ b/Sources/LanguageServerProtocol/Additions/TokenRepresentation.swift
@@ -2,10 +2,14 @@ import Foundation
 
 /// A structure representing a Semantic Token.
 public struct Token: Codable, Hashable, Sendable {
+	/// The range of the token in the document.
 	public let range: LSPRange
+	/// The type of the token.
 	public let tokenType: String
+	/// The set of modifier names applied to the token.
 	public let modifiers: Set<String>
 
+	/// Creates an instance from its parts.
 	public init(range: LSPRange, tokenType: String, modifiers: Set<String> = Set()) {
 		self.range = range
 		self.tokenType = tokenType
@@ -16,9 +20,12 @@ public struct Token: Codable, Hashable, Sendable {
 /// Stores and updates raw Semantic Token data and converts it into Tokens.
 public final class TokenRepresentation {
 	private var data: [UInt32]
+	/// The result id of the last applied response, if any.
 	public private(set) var lastResultId: String?
+	/// The legend used to interpret token types and modifiers.
 	public let legend: SemanticTokensLegend
 
+	/// Creates a new representation with the given legend.
 	public init(legend: SemanticTokensLegend) {
 		self.data = []
 		self.legend = legend
@@ -130,6 +137,7 @@ public final class TokenRepresentation {
 }
 
 extension TokenRepresentation {
+	/// Applies a delta response to the token representation.
 	public func applyResponse(_ response: SemanticTokensDeltaResponse) -> [LSPRange] {
 		switch response {
 		case .optionA(let fullResponse):
@@ -145,6 +153,7 @@ extension TokenRepresentation {
 		}
 	}
 
+	/// Applies a full response to the token representation.
 	public func applyResponse(_ response: SemanticTokensResponse) -> [LSPRange] {
 		guard let response = response else {
 			self.lastResultId = nil

--- a/Sources/LanguageServerProtocol/BaseProtocol.swift
+++ b/Sources/LanguageServerProtocol/BaseProtocol.swift
@@ -1,67 +1,94 @@
 import Foundation
 import JSONRPC
 
+/// The LSP any type.
 public typealias LSPAny = JSONValue
 
+/// A non-document URI, transferred as a string.
 public typealias URI = String
 
+/// A document URI, transferred as a string whose contents can be parsed as a valid URI.
 public typealias DocumentUri = String
 
+/// A token used to report progress, provided by the client or server.
 public typealias ProgressToken = TwoTypeOption<Int, String>
 
+/// Parameters for the `$/cancelRequest` notification.
 public struct CancelParams: Hashable, Codable, Sendable {
+	/// The request id to cancel.
 	public var id: TwoTypeOption<Int, String>
 
+	/// Creates an instance with a numeric request id.
 	public init(id: Int) {
 		self.id = .optionA(id)
 	}
 
+	/// Creates an instance with a string request id.
 	public init(id: String) {
 		self.id = .optionB(id)
 	}
 }
 
+/// Parameters for the `$/progress` notification.
 public struct ProgressParams: Hashable, Codable, Sendable {
+	/// The progress token provided by the client or server.
 	public var token: ProgressToken
+	/// The progress data.
 	public var value: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(token: ProgressToken, value: LSPAny? = nil) {
 		self.token = token
 		self.value = value
 	}
 }
 
+/// Parameters for the `$/logTrace` notification.
 public struct LogTraceParams: Hashable, Codable, Sendable {
+	/// The message to log.
 	public var string: String
+	/// Additional verbose information, if any.
 	public var verbose: String?
 
+	/// Creates an instance from its parts.
 	public init(string: String, verbose: String? = nil) {
 		self.string = string
 		self.verbose = verbose
 	}
 }
 
+/// The level of verbosity for trace output.
 public enum TraceValue: String, Hashable, Codable, Sendable {
+	/// Tracing is disabled.
 	case off
+	/// Only messages are traced.
 	case messages
+	/// Messages and verbose output are traced.
 	case verbose
 }
 
+/// Parameters for the `$/setTrace` notification.
 public struct SetTraceParams: Hashable, Codable, Sendable {
+	/// The new trace value.
 	public var value: TraceValue
 
+	/// Creates an instance from its parts.
 	public init(value: TraceValue) {
 		self.value = value
 	}
 }
 
+/// A container for an array of capability values advertised during initialization.
 public struct ValueSet<T: Hashable & Codable>: Hashable, Codable {
+	/// The supported values.
 	public var valueSet: [T]
 
+	/// Creates an instance from an array of values.
 	public init(valueSet: [T]) {
 		self.valueSet = valueSet
 	}
 
+	/// Creates an instance containing a single value.
 	public init(value: T) {
 		self.valueSet = [value]
 	}
@@ -76,6 +103,7 @@ extension ValueSet: ExpressibleByArrayLiteral {
 }
 
 extension ValueSet where T: CaseIterable {
+	/// A value set containing all cases.
 	public static var all: ValueSet<T> {
 		return ValueSet(valueSet: Array(T.allCases))
 	}
@@ -84,6 +112,7 @@ extension ValueSet where T: CaseIterable {
 extension ValueSet: Sendable where T: Sendable {
 }
 
+/// A well-known language identifier as defined by the LSP specification.
 public enum LanguageIdentifier: String, Codable, CaseIterable, Sendable {
 	case abap
 	case windowsbat = "bat"
@@ -144,11 +173,16 @@ public enum LanguageIdentifier: String, Codable, CaseIterable, Sendable {
 	case yaml
 }
 
+/// A document filter denotes a document through properties like language, scheme, or pattern.
 public struct DocumentFilter: Codable, Hashable, Sendable {
+	/// A language id, like `typescript`.
 	public let language: LanguageIdentifier?
+	/// A URI scheme, like `file` or `untitled`.
 	public let scheme: String?
+	/// A glob pattern, like `*.{ts,js}`.
 	public let pattern: String?
 
+	/// Creates an instance from its parts.
 	public init(language: LanguageIdentifier? = nil, scheme: String? = nil, pattern: String? = nil)
 	{
 		self.language = language
@@ -157,15 +191,20 @@ public struct DocumentFilter: Codable, Hashable, Sendable {
 	}
 }
 
+/// The combination of one or more document filters.
 public typealias DocumentSelector = [DocumentFilter]
 
+/// An identifier for a text document using its URI.
 public struct TextDocumentIdentifier: Codable, Hashable, Sendable {
+	/// The text document's URI.
 	public var uri: DocumentUri
 
+	/// Creates an instance from a document URI.
 	public init(uri: DocumentUri) {
 		self.uri = uri
 	}
 
+	/// Creates an instance from a file path, converting it to a `file://` URI.
 	public init(path: String) {
 		self.uri = URL(fileURLWithPath: path).absoluteString
 	}

--- a/Sources/LanguageServerProtocol/BasicStructures.swift
+++ b/Sources/LanguageServerProtocol/BasicStructures.swift
@@ -1,16 +1,24 @@
 import Foundation
 
+/// A position in a text document expressed as zero-based line and zero-based character offset.
 public struct Position: Codable, Hashable, Sendable {
+	/// The origin position (line 0, character 0).
 	public static let zero = Position(line: 0, character: 0)
 
+	/// Zero-based line position in a document.
 	public let line: Int
+	/// Zero-based character offset on a line, interpreted according to the negotiated `PositionEncodingKind`.
 	public let character: Int
 
+	/// Creates an instance from 0-based line and character offsets.
+	/// 
+	/// Note: `character` is interpreted according to the negotiated `PositionEncodingKind`.
 	public init(line: Int, character: Int) {
 		self.line = line
 		self.character = character
 	}
 
+	/// Creates an instance from a (line, character) tuple.
 	public init(_ pair: (Int, Int)) {
 		self.line = pair.0
 		self.character = pair.1
@@ -34,31 +42,42 @@ extension Position: Comparable {
 }
 
 extension Range where Bound == Position {
+	/// Creates a half-open range from explicit start and end positions.
 	public init(_ start: Position, _ end: Position) {
 		self.init(uncheckedBounds: (lower: start, upper: end))
 	}
 
+	/// Creates a half-open range from an `LSPRange`.
 	public init(_ range: LSPRange) {
 		self.init(uncheckedBounds: (lower: range.start, upper: range.end))
 	}
 }
 
+/// A range in a text document expressed as zero-based start and end positions.
+///
+/// The end position is exclusive.
 public struct LSPRange: Codable, Hashable, Sendable {
+	/// The empty range at the origin position.
 	public static let zero = LSPRange(start: .zero, end: .zero)
 
+	/// The range's start position (inclusive).
 	public let start: Position
+	/// The range's end position (exclusive).
 	public let end: Position
 
+	/// Creates an instance from its parts.
 	public init(start: Position, end: Position) {
 		self.start = start
 		self.end = end
 	}
 
+	/// Creates an instance from (line, character) tuples.
 	public init(startPair: (Int, Int), endPair: (Int, Int)) {
 		self.start = Position(startPair)
 		self.end = Position(endPair)
 	}
 
+	/// Creates an instance from a `Range<Position>`.
 	public init(_ other: Range<Position>) {
 		self.start = other.lowerBound
 		self.end = other.upperBound
@@ -72,6 +91,7 @@ public struct LSPRange: Codable, Hashable, Sendable {
 		return contains(other.start) || contains(other.end)
 	}
 
+	/// Whether start equals end.
 	public var isEmpty: Bool {
 		return start == end
 	}
@@ -83,12 +103,18 @@ extension LSPRange: CustomStringConvertible {
 	}
 }
 
+/// An item to transfer a text document from the client to the server.
 public struct TextDocumentItem: Codable, Hashable, Sendable {
+	/// The text document's URI.
 	public let uri: DocumentUri
+	/// The text document's language identifier.
 	public let languageId: String
+	/// The version number of this document (increases after each change, including undo/redo).
 	public let version: Int
+	/// The content of the opened text document.
 	public let text: String
 
+	/// Creates an instance from its parts.
 	public init(uri: DocumentUri, languageId: LanguageIdentifier, version: Int, text: String) {
 		self.uri = uri
 		self.languageId = languageId.rawValue
@@ -96,6 +122,7 @@ public struct TextDocumentItem: Codable, Hashable, Sendable {
 		self.text = text
 	}
 
+	/// Creates an instance from its parts using a raw language id string.
 	public init(uri: DocumentUri, languageId: String, version: Int, text: String) {
 		self.uri = uri
 		self.languageId = languageId
@@ -104,10 +131,14 @@ public struct TextDocumentItem: Codable, Hashable, Sendable {
 	}
 }
 
+/// An identifier to denote a specific version of a text document.
 public struct VersionedTextDocumentIdentifier: Codable, Hashable, Sendable {
+	/// The text document's URI.
 	public let uri: DocumentUri
+	/// The version number of this document, if known.
 	public let version: Int?
 
+	/// Creates an instance from its parts.
 	public init(uri: DocumentUri, version: Int?) {
 		self.uri = uri
 		self.version = version
@@ -122,21 +153,30 @@ extension VersionedTextDocumentIdentifier: CustomStringConvertible {
 	}
 }
 
+/// A location inside a resource, such as a line inside a text file.
 public struct Location: Codable, Hashable, Sendable {
+	/// The document URI.
 	public let uri: DocumentUri
+	/// The range within the document.
 	public let range: LSPRange
 
+	/// Creates an instance from its parts.
 	public init(uri: DocumentUri, range: LSPRange) {
 		self.uri = uri
 		self.range = range
 	}
 }
 
+/// A reference to a command identified by a string.
 public struct Command: Codable, Hashable, Sendable {
+	/// A title shown in the UI for this command.
 	public let title: String
+	/// The identifier of the actual command handler.
 	public let command: String
+	/// Arguments passed to the command handler, if any.
 	public let arguments: [LSPAny]?
 
+	/// Creates an instance from its parts.
 	public init(title: String, command: String, arguments: [LSPAny]? = nil) {
 		self.title = title
 		self.command = command
@@ -144,6 +184,7 @@ public struct Command: Codable, Hashable, Sendable {
 	}
 }
 
+/// The kind of a symbol.
 public enum SymbolKind: Int, CaseIterable, Hashable, Codable, Sendable {
 	case file = 1
 	case module = 2
@@ -173,20 +214,28 @@ public enum SymbolKind: Int, CaseIterable, Hashable, Codable, Sendable {
 	case typeParameter = 26
 }
 
+/// The format used for markup content.
 public enum MarkupKind: String, Codable, Hashable, Sendable {
+	/// Plain text.
 	case plaintext
+	/// Markdown.
 	case markdown
 }
 
+/// A parameter literal used in requests to pass a text document and a position inside that document.
 public struct TextDocumentPositionParams: Codable, Hashable, Sendable {
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public let position: Position
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier, position: Position) {
 		self.textDocument = textDocument
 		self.position = position
 	}
 
+	/// Creates an instance from a document URI and position.
 	public init(uri: DocumentUri, position: Position) {
 		let textDocId = TextDocumentIdentifier(uri: uri)
 
@@ -194,19 +243,25 @@ public struct TextDocumentPositionParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// A language-tagged string value used in legacy hover results.
 public struct LanguageStringPair: Codable, Hashable, Sendable {
+	/// The language identifier.
 	public let language: LanguageIdentifier
+	/// The string value.
 	public let value: String
 
+	/// Creates an instance from its parts.
 	public init(language: LanguageIdentifier, value: String) {
 		self.language = language
 		self.value = value
 	}
 }
 
+/// A marked string either as a plain string or a language-tagged value.
 public typealias MarkedString = TwoTypeOption<String, LanguageStringPair>
 
 extension MarkedString {
+	/// The string value regardless of variant.
 	public var value: String {
 		switch self {
 		case .optionA(let string):
@@ -217,17 +272,25 @@ extension MarkedString {
 	}
 }
 
+/// A `MarkupContent` literal represents a string value with a given format (plaintext or markdown).
 public struct MarkupContent: Codable, Hashable, Sendable {
+	/// The markup format.
 	public let kind: MarkupKind
+	/// The content string.
 	public let value: String
 
+	/// Creates an instance from its parts.
 	public init(kind: MarkupKind, value: String) {
 		self.kind = kind
 		self.value = value
 	}
 }
 
+/// A link between a source and a target location.
+///
+/// - Since: 3.14.0
 public struct LocationLink: Codable, Hashable, Sendable {
+	/// Creates an instance from its parts.
 	public init(
 		originSelectionRange: LSPRange? = nil, targetUri: String, targetRange: LSPRange,
 		targetSelectionRange: LSPRange
@@ -238,8 +301,12 @@ public struct LocationLink: Codable, Hashable, Sendable {
 		self.targetSelectionRange = targetSelectionRange
 	}
 
+	/// The span of the origin of this link used as the underlined range for mouse interaction, if any.
 	public let originSelectionRange: LSPRange?
+	/// The target resource identifier.
 	public let targetUri: String
+	/// The full target range (used for highlighting).
 	public let targetRange: LSPRange
+	/// The range that should be selected and revealed when this link is followed.
 	public let targetSelectionRange: LSPRange
 }

--- a/Sources/LanguageServerProtocol/Client.swift
+++ b/Sources/LanguageServerProtocol/Client.swift
@@ -1,10 +1,15 @@
 import Foundation
 
+/// A general parameter to register a capability.
 public struct Registration: Codable, Hashable, Sendable {
+	/// The id used to register the request. Can be used to deregister later.
 	public var id: String
+	/// The method/capability to register for.
 	public var method: String
+	/// Options necessary for the registration, if any.
 	public var registerOptions: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(id: String, method: String, registerOptions: LSPAny? = nil) {
 		self.id = id
 		self.method = method
@@ -45,28 +50,38 @@ extension Registration {
 		}
 	}
 
+	/// The decoded server registration, if the method is recognized.
 	public var serverRegistration: ServerRegistration? {
 		return try? decodeServerRegistration()
 	}
 }
 
+/// Parameters for the `client/registerCapability` request.
 public struct RegistrationParams: Codable, Hashable, Sendable {
+	/// The registrations to apply.
 	public var registrations: [Registration]
 
+	/// Creates an instance from its parts.
 	public init(registrations: [Registration]) {
 		self.registrations = registrations
 	}
 
+	/// The decoded server registrations for all recognized methods.
 	public var serverRegistrations: [ServerRegistration] {
 		return registrations.compactMap({ $0.serverRegistration })
 	}
 }
 
+/// A general parameter to unregister a capability.
 public struct Unregistration: Codable, Hashable, Sendable {
+	/// The id used to unregister the request or notification.
 	public var id: String
+	/// The method/capability to unregister for.
 	public var method: String
 }
 
+/// Parameters for the `client/unregisterCapability` request.
 public struct UnregistrationParams: Codable, Hashable, Sendable {
+	/// The unregistrations to apply.
 	public var unregistrations: [Unregistration]
 }

--- a/Sources/LanguageServerProtocol/Client/JSONRPCServerConnection.swift
+++ b/Sources/LanguageServerProtocol/Client/JSONRPCServerConnection.swift
@@ -1,7 +1,9 @@
 import Foundation
 import JSONRPC
 
+/// A concrete `ServerConnection` implementation that communicates over JSON-RPC.
 public actor JSONRPCServerConnection: ServerConnection {
+	/// The sequence of server events.
 	public let eventSequence: EventSequence
 	private let eventContinuation: EventSequence.Continuation
 	private var eventTask: Task<Void, Never>?

--- a/Sources/LanguageServerProtocol/Client/MockServer.swift
+++ b/Sources/LanguageServerProtocol/Client/MockServer.swift
@@ -8,19 +8,24 @@ extension AsyncSequence {
 
 /// Simulate LSP communication.
 public actor MockServer: ServerConnection {
+	/// A message sent from the client to the server.
 	public enum ClientMessage: Equatable, Sendable {
+		/// A notification from the client.
 		case notification(ClientNotification)
+		/// A request from the client.
 		case request(ClientRequest)
 	}
 
 	public typealias ClientMessageSequence = AsyncStream<ClientMessage>
 	private typealias ResponseDataSequence = AsyncStream<Data>
 
+	/// The sequence of server events.
 	public let eventSequence: EventSequence
 	private let eventContinuation: EventSequence.Continuation
 
 	private var mockResponses = [Data]()
 
+	/// The sequence of sent client messages.
 	public let sentMessageSequence: ClientMessageSequence
 	private let sentMessageContinuation: ClientMessageSequence.Continuation
 

--- a/Sources/LanguageServerProtocol/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ClientCapabilities.swift
@@ -1,41 +1,62 @@
 import Foundation
 
+/// A client capability that indicates dynamic registration support.
 public struct DynamicRegistrationClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
 
+	/// Creates an instance from its parts.
 	public init(dynamicRegistration: Bool) {
 		self.dynamicRegistration = dynamicRegistration
 	}
 }
 
+/// A client capability that indicates dynamic registration and link support.
 public struct DynamicRegistrationLinkSupportClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// Whether the client supports `LocationLink` responses.
 	public var linkSupport: Bool?
 
+	/// Creates an instance from its parts.
 	public init(dynamicRegistration: Bool, linkSupport: Bool) {
 		self.dynamicRegistration = dynamicRegistration
 		self.linkSupport = linkSupport
 	}
 }
 
+/// The kind of resource operation supported by the client.
 public enum ResourceOperationKind: String, Codable, Hashable, Sendable {
+	/// Creating resources.
 	case create
+	/// Renaming resources.
 	case rename
+	/// Deleting resources.
 	case delete
 }
 
+/// How the client handles workspace edit failures.
 public enum FailureHandlingKind: String, Codable, Hashable, Sendable {
+	/// Applying the workspace edit is simply aborted if one of the changes fails.
 	case abort
+	/// All operations are executed transactionally; they all succeed or all fail.
 	case transactional
+	/// Text-only changes are applied transactionally; other changes are aborted.
 	case textOnlyTransactional
+	/// The client tries to undo already-applied changes.
 	case undo
 }
 
+/// Client capabilities for workspace edits.
 public struct WorkspaceClientCapabilityEdit: Codable, Hashable, Sendable {
+	/// Whether the client supports versioned document changes.
 	public let documentChanges: Bool?
+	/// The resource operations the client supports.
 	public let resourceOperations: [ResourceOperationKind]?
+	/// The failure handling strategy the client uses.
 	public let failureHandling: FailureHandlingKind?
 
+	/// Creates an instance from its parts.
 	public init(
 		documentChanges: Bool?,
 		resourceOperations: [ResourceOperationKind]?,
@@ -47,39 +68,55 @@ public struct WorkspaceClientCapabilityEdit: Codable, Hashable, Sendable {
 	}
 }
 
+/// Client capabilities for `workspace/didChangeConfiguration`.
 public typealias DidChangeConfigurationClientCapabilities = GenericDynamicRegistration
 
+/// Client capabilities for `workspace/didChangeWatchedFiles`.
 public typealias DidChangeWatchedFilesClientCapabilities = GenericDynamicRegistration
 
+/// Client capabilities for the `window/showDocument` request.
 public struct ShowDocumentClientCapabilities: Hashable, Codable, Sendable {
+	/// Whether the client has support for the show document request.
 	public var support: Bool
 
+	/// Creates an instance from its parts.
 	public init(support: Bool) {
 		self.support = support
 	}
 }
 
+/// Client capabilities for the `window/showMessageRequest` request.
 public struct ShowMessageRequestClientCapabilities: Hashable, Codable, Sendable {
+	/// Capabilities specific to the `MessageActionItem` type.
 	public struct MessageActionItemCapabilities: Hashable, Codable, Sendable {
+		/// Whether the client supports additional attributes which are preserved and sent back to the server.
 		public var additionalPropertiesSupport: Bool?
 
+		/// Creates an instance from its parts.
 		public init(additionalPropertiesSupport: Bool?) {
 			self.additionalPropertiesSupport = additionalPropertiesSupport
 		}
 	}
 
+	/// Capabilities specific to `MessageActionItem`, if any.
 	public var messageActionItem: MessageActionItemCapabilities?
 
+	/// Creates an instance from its parts.
 	public init(messageActionItem: MessageActionItemCapabilities?) {
 		self.messageActionItem = messageActionItem
 	}
 }
 
+/// Client capabilities for the window.
 public struct WindowClientCapabilities: Hashable, Codable, Sendable {
+	/// Whether the client supports the `window/workDoneProgress/create` request.
 	public var workDoneProgress: Bool?
+	/// Capabilities for the `window/showMessageRequest` method.
 	public var showMessage: ShowMessageRequestClientCapabilities?
+	/// Capabilities for the `window/showDocument` method.
 	public var showDocument: ShowDocumentClientCapabilities?
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneProgress: Bool,
 		showMessage: ShowMessageRequestClientCapabilities?,
@@ -91,21 +128,30 @@ public struct WindowClientCapabilities: Hashable, Codable, Sendable {
 	}
 }
 
+/// Client capabilities specific to regular expressions.
 public struct RegularExpressionsClientCapabilities: Hashable, Codable, Sendable {
+	/// The engine's name.
 	public var engine: String
+	/// The engine's version, if any.
 	public var version: String?
 
+	/// Creates an instance from its parts.
 	public init(engine: String, version: String? = nil) {
 		self.engine = engine
 		self.version = version
 	}
 }
 
+/// Client capabilities for rendering Markdown content.
 public struct MarkdownClientCapabilities: Hashable, Codable, Sendable {
+	/// The name of the Markdown parser.
 	public var parser: String
+	/// The version of the parser, if any.
 	public var version: String?
+	/// The list of HTML tags the client allows in Markdown, if any.
 	public var allowedTags: [String]?
 
+	/// Creates an instance from its parts.
 	public init(parser: String, version: String? = nil, allowedTags: [String]? = nil) {
 		self.parser = parser
 		self.version = version
@@ -113,10 +159,14 @@ public struct MarkdownClientCapabilities: Hashable, Codable, Sendable {
 	}
 }
 
+/// General client capabilities.
 public struct GeneralClientCapabilities: Hashable, Codable, Sendable {
+	/// Client capabilities for regular expressions.
 	public var regularExpressions: RegularExpressionsClientCapabilities?
+	/// Client capabilities for Markdown rendering.
 	public var markdown: MarkdownClientCapabilities?
 
+	/// Creates an instance from its parts.
 	public init(
 		regularExpressions: RegularExpressionsClientCapabilities?,
 		markdown: MarkdownClientCapabilities?
@@ -126,12 +176,18 @@ public struct GeneralClientCapabilities: Hashable, Codable, Sendable {
 	}
 }
 
+/// Client capabilities for text document synchronization.
 public struct TextDocumentSyncClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether text document synchronization supports dynamic registration.
 	public let dynamicRegistration: Bool?
+	/// Whether the client supports the `willSave` notification.
 	public let willSave: Bool?
+	/// Whether the client supports the `willSaveWaitUntil` request.
 	public let willSaveWaitUntil: Bool?
+	/// Whether the client supports the `didSave` notification.
 	public let didSave: Bool?
 
+	/// Creates an instance from its parts.
 	public init(dynamicRegistration: Bool, willSave: Bool, willSaveWaitUntil: Bool, didSave: Bool) {
 		self.dynamicRegistration = dynamicRegistration
 		self.willSave = willSave
@@ -140,36 +196,66 @@ public struct TextDocumentSyncClientCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// Text document specific client capabilities.
 public struct TextDocumentClientCapabilities: Codable, Hashable, Sendable {
+	/// Capabilities for text document synchronization.
 	public var synchronization: TextDocumentSyncClientCapabilities?
+	/// Capabilities for `textDocument/completion`.
 	public var completion: CompletionClientCapabilities?
+	/// Capabilities for `textDocument/hover`.
 	public var hover: HoverClientCapabilities?
+	/// Capabilities for `textDocument/signatureHelp`.
 	public var signatureHelp: SignatureHelpClientCapabilities?
+	/// Capabilities for `textDocument/declaration`.
 	public var declaration: DeclarationClientCapabilities?
+	/// Capabilities for `textDocument/definition`.
 	public var definition: DefinitionClientCapabilities?
+	/// Capabilities for `textDocument/typeDefinition`.
 	public var typeDefinition: TypeDefinitionClientCapabilities?
+	/// Capabilities for `textDocument/implementation`.
 	public var implementation: ImplementationClientCapabilities?
+	/// Capabilities for `textDocument/references`.
 	public var references: ReferenceClientCapabilities?
+	/// Capabilities for `textDocument/documentHighlight`.
 	public var documentHighlight: DocumentHighlightClientCapabilities?
+	/// Capabilities for `textDocument/documentSymbol`.
 	public var documentSymbol: DocumentSymbolClientCapabilities?
+	/// Capabilities for `textDocument/codeAction`.
 	public var codeAction: CodeActionClientCapabilities?
+	/// Capabilities for `textDocument/codeLens`.
 	public var codeLens: CodeLensClientCapabilities?
+	/// Capabilities for `textDocument/documentLink`.
 	public var documentLink: DocumentLinkClientCapabilities?
+	/// Capabilities for `textDocument/documentColor`.
 	public var colorProvider: DocumentColorClientCapabilities?
+	/// Capabilities for `textDocument/formatting`.
 	public var formatting: DocumentFormattingClientCapabilities?
+	/// Capabilities for `textDocument/rangeFormatting`.
 	public var rangeFormatting: DocumentRangeFormattingClientCapabilities?
+	/// Capabilities for `textDocument/onTypeFormatting`.
 	public var onTypeFormatting: DocumentOnTypeFormattingClientCapabilities?
+	/// Capabilities for `textDocument/rename`.
 	public var rename: RenameClientCapabilities?
+	/// Capabilities for `textDocument/publishDiagnostics`.
 	public var publishDiagnostics: PublishDiagnosticsClientCapabilities?
+	/// Capabilities for `textDocument/foldingRange`.
 	public var foldingRange: FoldingRangeClientCapabilities?
+	/// Capabilities for `textDocument/selectionRange`.
 	public var selectionRange: SelectionRangeClientCapabilities?
+	/// Capabilities for `textDocument/linkedEditingRange`.
 	public var linkedEditingRange: LinkedEditingRangeClientCapabilities?
+	/// Capabilities for `textDocument/prepareCallHierarchy`.
 	public var callHierarchy: CallHierarchyClientCapabilities?
+	/// Capabilities for `textDocument/semanticTokens`.
 	public var semanticTokens: SemanticTokensClientCapabilities?
+	/// Capabilities for `textDocument/moniker`.
 	public var moniker: MonikerClientCapabilities?
+	/// Capabilities for `textDocument/inlayHint`.
 	public var inlayHint: InlayHintClientCapabilities?
+	/// Capabilities for `textDocument/diagnostic`.
 	public var diagnostic: DiagnosticClientCapabilities?
 
+	/// Creates an instance from its parts.
 	public init(
 		synchronization: TextDocumentSyncClientCapabilities? = nil,
 		completion: CompletionClientCapabilities? = nil,
@@ -230,17 +316,28 @@ public struct TextDocumentClientCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// The capabilities provided by the client (editor or tool).
 public struct ClientCapabilities: Codable, Hashable, Sendable {
+	/// Workspace specific client capabilities.
 	public struct Workspace: Codable, Hashable, Sendable {
+		/// Client capabilities for file operations.
 		public struct FileOperations: Codable, Hashable, Sendable {
+			/// Whether dynamic registration is supported.
 			public var dynamicRegistration: Bool?
+			/// The client supports `didCreateFiles` notifications.
 			public var didCreate: Bool?
+			/// The client supports `willCreateFiles` requests.
 			public var willCreate: Bool?
+			/// The client supports `didRenameFiles` notifications.
 			public var didRename: Bool?
+			/// The client supports `willRenameFiles` requests.
 			public var willRename: Bool?
+			/// The client supports `didDeleteFiles` notifications.
 			public var didDelete: Bool?
+			/// The client supports `willDeleteFiles` requests.
 			public var willDelete: Bool?
 
+			/// Creates an instance from its parts.
 			public init(
 				dynamicRegistration: Bool? = nil,
 				didCreate: Bool? = nil,
@@ -260,18 +357,30 @@ public struct ClientCapabilities: Codable, Hashable, Sendable {
 			}
 		}
 
+		/// Whether the client supports applying batch edits to the workspace.
 		public let applyEdit: Bool?
+		/// Capabilities for `WorkspaceEdit`.
 		public let workspaceEdit: WorkspaceClientCapabilityEdit?
+		/// Capabilities for `workspace/didChangeConfiguration`.
 		public let didChangeConfiguration: DidChangeConfigurationClientCapabilities?
+		/// Capabilities for `workspace/didChangeWatchedFiles`.
 		public let didChangeWatchedFiles: GenericDynamicRegistration?
+		/// Capabilities for `workspace/symbol`.
 		public let symbol: WorkspaceSymbolClientCapabilities?
+		/// Capabilities for `workspace/executeCommand`.
 		public let executeCommand: GenericDynamicRegistration?
+		/// Whether the client supports workspace folders.
 		public let workspaceFolders: Bool?
+		/// Whether the client supports `workspace/configuration` requests.
 		public let configuration: Bool?
+		/// Capabilities for workspace semantic tokens.
 		public let semanticTokens: SemanticTokensWorkspaceClientCapabilities?
+		/// Capabilities for workspace code lens.
 		public let codeLens: CodeLensWorkspaceClientCapabilities?
+		/// Capabilities for file operations.
 		public let fileOperations: FileOperations?
 
+		/// Creates an instance from its parts.
 		public init(
 			applyEdit: Bool,
 			workspaceEdit: WorkspaceClientCapabilityEdit?,
@@ -299,12 +408,18 @@ public struct ClientCapabilities: Codable, Hashable, Sendable {
 		}
 	}
 
+	/// Workspace specific capabilities.
 	public let workspace: Workspace?
+	/// Text document specific capabilities.
 	public let textDocument: TextDocumentClientCapabilities?
+	/// Window specific capabilities.
 	public var window: WindowClientCapabilities?
+	/// General client capabilities.
 	public var general: GeneralClientCapabilities?
+	/// Experimental client capabilities.
 	public let experimental: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(
 		workspace: Workspace?, textDocument: TextDocumentClientCapabilities?,
 		window: WindowClientCapabilities?, general: GeneralClientCapabilities?,

--- a/Sources/LanguageServerProtocol/ErrorCodes.swift
+++ b/Sources/LanguageServerProtocol/ErrorCodes.swift
@@ -1,91 +1,80 @@
-// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#responseMessage
+/// Error codes defined by JSON-RPC and the Language Server Protocol.
 public enum ErrorCodes {
+	/// Invalid JSON was received by the server.
 	public static let ParseError = -32700
+	/// The JSON sent is not a valid request object.
 	public static let InvalidRequest = -32600
+	/// The method does not exist or is not available.
 	public static let MethodNotFound = -32601
+	/// Invalid method parameters.
 	public static let InvalidParams = -32602
+	/// Internal JSON-RPC error.
 	public static let InternalError = -32603
 
-	/**
-	 * This is the start range of JSON-RPC reserved error codes.
-	 * It doesn't denote a real error code. No LSP error codes should
-	 * be defined between the start and end range. For backwards
-	 * compatibility the `ServerNotInitialized` and the `UnknownErrorCode`
-	 * are left in the range.
-	 *
-	 * @since 3.16.0
-	 */
+	/// The start range of JSON-RPC reserved error codes.
+	///
+	/// It doesn't denote a real error code. No LSP error codes should
+	/// be defined between the start and end range. For backwards
+	/// compatibility the `ServerNotInitialized` and the `UnknownErrorCode`
+	/// are left in the range.
+	///
+	/// - Since: 3.16.0
 	public static let jsonrpcReservedErrorRangeStart = -32099
-	/** @deprecated use jsonrpcReservedErrorRangeStart */
+	/// - Note: Deprecated, use `jsonrpcReservedErrorRangeStart`.
 	public static let serverErrorStart = jsonrpcReservedErrorRangeStart
 
-	/**
-	 * Error code indicating that a server received a notification or
-	 * request before the server has received the `initialize` request.
-	 */
+	/// The server received a notification or request before the `initialize` request.
 	public static let ServerNotInitialized = -32002
+	/// An unknown error code.
 	public static let UnknownErrorCode = -32001
 
-	/**
-	 * This is the end range of JSON-RPC reserved error codes.
-	 * It doesn't denote a real error code.
-	 *
-	 * @since 3.16.0
-	 */
+	/// The end range of JSON-RPC reserved error codes.
+	///
+	/// It doesn't denote a real error code.
+	///
+	/// - Since: 3.16.0
 	public static let jsonrpcReservedErrorRangeEnd = -32000
-	/** @deprecated use jsonrpcReservedErrorRangeEnd */
+	/// - Note: Deprecated, use `jsonrpcReservedErrorRangeEnd`.
 	public static let serverErrorEnd = jsonrpcReservedErrorRangeEnd
 
-	/**
-	 * This is the start range of LSP reserved error codes.
-	 * It doesn't denote a real error code.
-	 *
-	 * @since 3.16.0
-	 */
+	/// The start range of LSP reserved error codes.
+	///
+	/// It doesn't denote a real error code.
+	///
+	/// - Since: 3.16.0
 	public static let lspReservedErrorRangeStart = -32899
 
-	/**
-	 * A request failed but it was syntactically correct, e.g the
-	 * method name was known and the parameters were valid. The error
-	 * message should contain human readable information about why
-	 * the request failed.
-	 *
-	 * @since 3.17.0
-	 */
+	/// A request failed but it was syntactically correct, e.g. the
+	/// method name was known and the parameters were valid. The error
+	/// message should contain human-readable information about why
+	/// the request failed.
+	///
+	/// - Since: 3.17.0
 	public static let RequestFailed = -32803
 
-	/**
-	 * The server cancelled the request. This error code should
-	 * only be used for requests that explicitly support being
-	 * server cancellable.
-	 *
-	 * @since 3.17.0
-	 */
+	/// The server cancelled the request.
+	///
+	/// This error code should only be used for requests that explicitly support
+	/// being server cancellable.
+	///
+	/// - Since: 3.17.0
 	public static let ServerCancelled = -32802
 
-	/**
-	 * The server detected that the content of a document got
-	 * modified outside normal conditions. A server should
-	 * NOT send this error code if it detects a content change
-	 * in it unprocessed messages. The result even computed
-	 * on an older state might still be useful for the client.
-	 *
-	 * If a client decides that a result is not of any use anymore
-	 * the client should cancel the request.
-	 */
+	/// The server detected that the content of a document got
+	/// modified outside normal conditions.
+	///
+	/// A server should NOT send this error code if it detects a content change
+	/// in its unprocessed messages. The result even computed on an older state
+	/// might still be useful for the client.
 	public static let ContentModified = -32801
 
-	/**
-	 * The client has canceled a request and a server as detected
-	 * the cancel.
-	 */
+	/// The client has canceled a request and the server has detected the cancel.
 	public static let RequestCancelled = -32800
 
-	/**
-	 * This is the end range of LSP reserved error codes.
-	 * It doesn't denote a real error code.
-	 *
-	 * @since 3.16.0
-	 */
+	/// The end range of LSP reserved error codes.
+	///
+	/// It doesn't denote a real error code.
+	///
+	/// - Since: 3.16.0
 	public static let lspReservedErrorRangeEnd = -32800
 }

--- a/Sources/LanguageServerProtocol/General.swift
+++ b/Sources/LanguageServerProtocol/General.swift
@@ -1,32 +1,51 @@
 import Foundation
 
+/// The initial trace setting sent during initialization.
 public enum Tracing: String, Codable, Hashable, Sendable {
+	/// Tracing is disabled.
 	case off
+	/// Only messages are traced.
 	case messages
+	/// Messages and verbose output are traced.
 	case verbose
 }
 
+/// Parameters for the `initialize` request.
 public struct InitializeParams: Codable, Hashable, Sendable {
+	/// Information about the client.
 	public struct ClientInfo: Codable, Hashable, Sendable {
+		/// The name of the client as defined by the client.
 		public let name: String
+		/// The client's version as defined by the client, if any.
 		public let version: String?
 
+		/// Creates an instance from its parts.
 		public init(name: String, version: String? = nil) {
 			self.name = name
 			self.version = version
 		}
 	}
 
+	/// The process id of the parent process that started the server, if known.
 	public let processId: Int?
+	/// Information about the client, if any.
 	public let clientInfo: ClientInfo?
+	/// The locale the client is currently showing the user interface in, if any.
 	public let locale: String?
+	/// The rootPath of the workspace, if any.
 	public let rootPath: String?
+	/// The rootUri of the workspace, if any.
 	public let rootUri: DocumentUri?
+	/// User-provided initialization options, if any.
 	public let initializationOptions: LSPAny?
+	/// The capabilities provided by the client (editor or tool).
 	public let capabilities: ClientCapabilities
+	/// The initial trace setting, if any.
 	public let trace: Tracing?
+	/// The workspace folders configured in the client when the server starts, if any.
 	public let workspaceFolders: [WorkspaceFolder]?
 
+	/// Creates an instance from its parts.
 	public init(
 		processId: Int?,
 		clientInfo: ClientInfo? = nil,
@@ -50,34 +69,37 @@ public struct InitializeParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// Information about the server.
 public struct ServerInfo: Codable, Hashable, Sendable {
-	/**
-	 * The name of the server as defined by the server.
-	 */
+	/// The name of the server as defined by the server.
 	public var name: String
-
-	/**
-	 * The server's version as defined by the server.
-	 */
+	/// The server's version as defined by the server, if any.
 	public var version: String?
 
+	/// Creates an instance from its parts.
 	public init(name: String, version: String?) {
 		self.name = name
 		self.version = version
 	}
 }
 
+/// The result returned from the `initialize` request.
 public struct InitializationResponse: Codable, Hashable, Sendable {
+	/// The capabilities the server provides.
 	public let capabilities: ServerCapabilities
+	/// Information about the server, if any.
 	public let serverInfo: ServerInfo?
 
+	/// Creates an instance from its parts.
 	public init(capabilities: ServerCapabilities, serverInfo: ServerInfo?) {
 		self.capabilities = capabilities
 		self.serverInfo = serverInfo
 	}
 }
 
+/// Parameters for the `initialized` notification (empty).
 public struct InitializedParams: Codable, Hashable, Sendable {
+	/// Creates an instance.
 	public init() {
 	}
 }

--- a/Sources/LanguageServerProtocol/LanguageFeatures/CallHeirarchy.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/CallHeirarchy.swift
@@ -1,17 +1,33 @@
 import Foundation
 
+/// Client capabilities for the call hierarchy feature.
+///
+/// - Since: 3.16.0
 public typealias CallHierarchyClientCapabilities = DynamicRegistrationClientCapabilities
 
+/// Server capabilities for the call hierarchy feature.
+///
+/// - Since: 3.16.0
 public typealias CallHierarchyOptions = WorkDoneProgressOptions
 
+/// Registration options for call hierarchy.
+///
+/// - Since: 3.16.0
 public typealias CallHierarchyRegistrationOptions =
 	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
+/// Parameters for the `textDocument/prepareCallHierarchy` request.
+///
+/// - Since: 3.16.0
 public struct CallHierarchyPrepareParams: Codable, Hashable, Sendable {
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public let position: Position
+	/// An optional work done progress token.
 	public let workDoneToken: ProgressToken?
 
+	/// Creates an instance from its parts.
 	public init(
 		textDocument: TextDocumentIdentifier, position: Position,
 		workDoneToken: ProgressToken? = nil
@@ -22,16 +38,28 @@ public struct CallHierarchyPrepareParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// Represents programming constructs like functions or constructors in the context of call hierarchy.
+///
+/// - Since: 3.16.0
 public struct CallHierarchyItem: Codable, Hashable, Sendable {
+	/// The name of this item.
 	public let name: String
+	/// The kind of this item.
 	public let kind: SymbolKind
+	/// Tags for this item.
 	public let tag: [SymbolTag]?
+	/// More detail for this item, e.g. the signature of a function.
 	public let detail: String?
+	/// The resource identifier of this item.
 	public let uri: DocumentUri
+	/// The range enclosing this symbol.
 	public let range: LSPRange
+	/// The range that should be selected and revealed when this symbol is being picked.
 	public let selectionRange: LSPRange
+	/// A data entry field that is preserved between request rounds.
 	public let data: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(
 		name: String,
 		kind: SymbolKind,
@@ -53,14 +81,22 @@ public struct CallHierarchyItem: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/prepareCallHierarchy`.
 public typealias CallHierarchyPrepareResponse = [CallHierarchyItem]?
 
+/// Parameters for the `callHierarchy/incomingCalls` request.
+///
+/// - Since: 3.16.0
 public struct CallHierarchyIncomingCallsParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public let partialResultToken: ProgressToken?
 
+	/// The call hierarchy item to resolve incoming calls for.
 	public let item: CallHierarchyItem
 
+	/// Creates an instance from its parts.
 	public init(
 		item: CallHierarchyItem, workDoneToken: ProgressToken? = nil,
 		partialResultToken: ProgressToken? = nil
@@ -71,10 +107,16 @@ public struct CallHierarchyIncomingCallsParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// Represents an incoming call, e.g. a caller of a method.
+///
+/// - Since: 3.16.0
 public struct CallHierarchyIncomingCall: Codable, Hashable, Sendable {
+	/// The item that makes the call.
 	public let from: CallHierarchyItem
+	/// The ranges at which the calls appear.
 	public let fromRanges: [LSPRange]
 
+	/// Creates an instance from its parts.
 	public init(
 		from: CallHierarchyItem, fromRanges: [LSPRange]
 	) {
@@ -83,18 +125,27 @@ public struct CallHierarchyIncomingCall: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `callHierarchy/incomingCalls`.
 public typealias CallHierarchyIncomingCallsResponse = [CallHierarchyIncomingCall]?
 
+/// Parameters for the `callHierarchy/outgoingCalls` request.
 public typealias CallHierarchyOutgoingCallsParams = CallHierarchyIncomingCallsParams
 
+/// Represents an outgoing call, e.g. calling a method from a given item.
+///
+/// - Since: 3.16.0
 public struct CallHierarchyOutgoingCall: Codable, Hashable, Sendable {
+	/// The item that is called.
 	public let to: CallHierarchyItem
+	/// The range at which this item is called.
 	public let fromRanges: [LSPRange]
 
+	/// Creates an instance from its parts.
 	public init(to: CallHierarchyItem, fromRanges: [LSPRange]) {
 		self.to = to
 		self.fromRanges = fromRanges
 	}
 }
 
+/// The response type for `callHierarchy/outgoingCalls`.
 public typealias CallHierarchyOutgoingCallsResponse = [CallHierarchyOutgoingCall]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/CodeAction.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/CodeAction.swift
@@ -1,44 +1,81 @@
 import Foundation
 
+/// The kind of a code action.
 public typealias CodeActionKind = String
 
 extension CodeActionKind {
+	/// Empty kind.
 	public static let Empty: CodeActionKind = ""
+	/// Base kind for quickfix actions.
 	public static let Quickfix: CodeActionKind = "quickfix"
+	/// Base kind for refactoring actions.
 	public static let Refactor: CodeActionKind = "refactor"
+	/// Base kind for refactoring extraction actions.
 	public static let RefactorExtract: CodeActionKind = "refactor.extract"
+	/// Base kind for refactoring inline actions.
 	public static let RefactorInline: CodeActionKind = "refactor.inline"
+	/// Base kind for refactoring rewrite actions.
 	public static let RefactorRewrite: CodeActionKind = "refactor.rewrite"
+	/// Base kind for source actions.
 	public static let Source: CodeActionKind = "source"
+	/// Base kind for organize imports source actions.
 	public static let SourceOrganizeImports: CodeActionKind = "source.organizeImports"
+	/// Base kind for fix-all source actions.
+	///
+	/// - Since: 3.17.0
 	public static let SourceFixAll: CodeActionKind = "source.fixAll"
 }
 
+/// Client capabilities for the `textDocument/codeAction` request.
 public struct CodeActionClientCapabilities: Codable, Hashable, Sendable {
+	/// Capabilities for code action literal support.
 	public struct CodeActionLiteralSupport: Codable, Hashable, Sendable {
+		/// The code action kind values the client supports.
 		public var codeActionKind: ValueSet<CodeActionKind>
 
+		/// Creates an instance from its parts.
 		public init(codeActionKind: ValueSet<CodeActionKind>) {
 			self.codeActionKind = codeActionKind
 		}
 	}
 
+	/// Capabilities for resolve support.
 	public struct ResolveSupport: Codable, Hashable, Sendable {
+		/// The properties that a client can resolve lazily.
 		public var properties: [String]
 
+		/// Creates an instance from its parts.
 		public init(properties: [String]) {
 			self.properties = properties
 		}
 	}
 
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// Capabilities for code action literal support.
 	public var codeActionLiteralSupport: CodeActionLiteralSupport?
+	/// Whether the client supports the `isPreferred` property.
+	///
+	/// - Since: 3.15.0
 	public var isPreferredSupport: Bool?
+	/// Whether the client supports the `disabled` property.
+	///
+	/// - Since: 3.16.0
 	public var disabledSupport: Bool?
+	/// Whether the client supports the `data` property.
+	///
+	/// - Since: 3.16.0
 	public var dataSupport: Bool?
+	/// Indicates which properties a client can resolve lazily.
+	///
+	/// - Since: 3.16.0
 	public var resolveSupport: ResolveSupport?
+	/// Whether the client honors change annotations.
+	///
+	/// - Since: 3.16.0
 	public var honorsChangeAnnotations: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		dynamicRegistration: Bool?,
 		codeActionLiteralSupport: CodeActionClientCapabilities.CodeActionLiteralSupport? = nil,
@@ -58,11 +95,18 @@ public struct CodeActionClientCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// Server capabilities for the `textDocument/codeAction` request.
 public struct CodeActionOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// The kinds of code actions the server supports.
 	public var codeActionKinds: [CodeActionKind]?
+	/// Whether the server supports resolving additional code action properties.
+	///
+	/// - Since: 3.16.0
 	public var resolveProvider: Bool?
 
+	/// Creates an instance from its parts.
 	public init(workDoneProgress: Bool?, codeActionKinds: [CodeActionKind]?, resolveProvider: Bool)
 	{
 		self.workDoneProgress = workDoneProgress
@@ -71,16 +115,28 @@ public struct CodeActionOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// The reason why code actions were requested.
+///
+/// - Since: 3.17.0
 public enum CodeActionTriggerKind: Int, Codable, Hashable, Sendable {
+	/// Code actions were explicitly requested by the user or an extension.
 	case invoked = 1
+	/// Code actions were requested automatically.
 	case automatic = 2
 }
 
+/// Contains additional diagnostic information about the context in which a code action is run.
 public struct CodeActionContext: Codable, Hashable, Sendable {
+	/// An array of diagnostics known on the client side overlapping the range.
 	public let diagnostics: [Diagnostic]
+	/// Requested kind of actions to return, if specified.
 	public let only: [CodeActionKind]?
+	/// The reason why code actions were requested.
+	///
+	/// - Since: 3.17.0
 	public let triggerKind: CodeActionTriggerKind?
 
+	/// Creates an instance from its parts.
 	public init(
 		diagnostics: [Diagnostic], only: [CodeActionKind]?,
 		triggerKind: CodeActionTriggerKind? = nil
@@ -91,11 +147,16 @@ public struct CodeActionContext: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/codeAction` request.
 public struct CodeActionParams: Codable, Hashable, Sendable {
+	/// The document in which the command was invoked.
 	public let textDocument: TextDocumentIdentifier
+	/// The range for which the command was invoked.
 	public let range: LSPRange
+	/// Context carrying additional information.
 	public let context: CodeActionContext
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier, range: LSPRange, context: CodeActionContext) {
 		self.textDocument = textDocument
 		self.range = range
@@ -103,20 +164,38 @@ public struct CodeActionParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// A code action represents a change that can be performed in code.
 public struct CodeAction: Codable, Hashable, Sendable {
+	/// Marks the code action as disabled.
 	public struct Disabled: Codable, Hashable, Sendable {
+		/// Whether the code action is disabled.
 		public var disabled: Bool
 	}
 
+	/// A short, human-readable title for this code action.
 	public var title: String
+	/// The kind of the code action.
 	public var kind: CodeActionKind?
+	/// The diagnostics that this code action resolves.
 	public var diagnostics: [Diagnostic]?
+	/// Marks this as a preferred action.
+	///
+	/// - Since: 3.15.0
 	public var isPreferred: Bool?
+	/// Marks that the code action cannot currently be applied.
+	///
+	/// - Since: 3.16.0
 	public var disabled: Disabled?
+	/// The workspace edit this code action performs.
 	public var edit: WorkspaceEdit?
+	/// A command this code action executes.
 	public var command: Command?
+	/// A data entry field that is preserved on a code action between request rounds.
+	///
+	/// - Since: 3.16.0
 	public var data: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(
 		title: String, kind: CodeActionKind? = nil, diagnostics: [Diagnostic]? = nil,
 		isPreferred: Bool? = nil, disabled: CodeAction.Disabled? = nil, edit: WorkspaceEdit? = nil,
@@ -133,4 +212,5 @@ public struct CodeAction: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/codeAction`.
 public typealias CodeActionResponse = [TwoTypeOption<Command, CodeAction>]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/CodeLens.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/CodeLens.swift
@@ -1,30 +1,43 @@
 import Foundation
 
+/// Client capabilities for the code lens feature.
 public typealias CodeLensClientCapabilities = DynamicRegistrationClientCapabilities
 
+/// Workspace client capabilities specific to code lens.
 public struct CodeLensWorkspaceClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether the client supports a refresh request sent from the server.
 	public var refreshSupport: Bool?
 
+	/// Creates an instance from its parts.
 	public init(refreshSupport: Bool? = nil) {
 		self.refreshSupport = refreshSupport
 	}
 }
 
+/// Server capabilities for the code lens feature.
 public struct CodeLensOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// Whether code lens has a resolve provider.
 	public var resolveProvider: Bool?
 
+	/// Creates an instance from its parts.
 	public init(workDoneProgress: Bool? = nil, resolveProvider: Bool? = nil) {
 		self.workDoneProgress = workDoneProgress
 		self.resolveProvider = resolveProvider
 	}
 }
 
+/// Registration options for code lens.
 public struct CodeLensRegistrationOptions: Codable, Hashable, Sendable {
+	/// A document selector to identify the scope of the registration.
 	public var documentSelector: DocumentSelector?
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// Whether code lens has a resolve provider.
 	public var resolveProvider: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil,
 		resolveProvider: Bool? = nil
@@ -35,11 +48,16 @@ public struct CodeLensRegistrationOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/codeLens` request.
 public struct CodeLensParams: Codable, Hashable, Sendable {
+	/// The document to request code lens for.
 	public var textDocument: TextDocumentIdentifier
+	/// An optional work done progress token.
 	public var workDoneToken: ProgressToken?
+	/// An optional token for partial result progress.
 	public var partialResultToken: ProgressToken?
 
+	/// Creates an instance from its parts.
 	public init(
 		textDocument: TextDocumentIdentifier, workDoneToken: ProgressToken? = nil,
 		partialResultToken: ProgressToken? = nil
@@ -50,11 +68,16 @@ public struct CodeLensParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// A code lens represents a command that should be shown along with source text.
 public struct CodeLens: Codable, Hashable, Sendable {
+	/// The range in which this code lens is valid.
 	public var range: LSPRange
+	/// The command this code lens represents.
 	public var command: Command?
+	/// A data entry field that is preserved on a code lens item between request rounds.
 	public var data: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(range: LSPRange, command: Command? = nil, data: LSPAny? = nil) {
 		self.range = range
 		self.command = command
@@ -62,6 +85,8 @@ public struct CodeLens: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/codeLens`.
 public typealias CodeLensResponse = [CodeLens]?
 
+/// The response type for `codeLens/resolve`.
 public typealias CodeLensResolveResponse = CodeLens

--- a/Sources/LanguageServerProtocol/LanguageFeatures/ColorPresentation.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/ColorPresentation.swift
@@ -1,12 +1,19 @@
 import Foundation
 
+/// Parameters for the `textDocument/colorPresentation` request.
 public struct ColorPresentationParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public let partialResultToken: ProgressToken?
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The color information to request presentations for.
 	public let color: Color
+	/// The range where the color would be inserted.
 	public let range: LSPRange
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil,
 		textDocument: TextDocumentIdentifier, color: Color, range: LSPRange
@@ -19,11 +26,16 @@ public struct ColorPresentationParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// A color presentation.
 public struct ColorPresentation: Codable, Hashable, Sendable {
+	/// The label of this color presentation.
 	public let label: String
+	/// An edit which is applied to a document when selecting this presentation.
 	public let textEdit: TextEdit?
+	/// Additional text edits applied when selecting this color presentation.
 	public let additionalTextEdits: [TextEdit]?
 
+	/// Creates an instance from its parts.
 	public init(
 		label: String, textEdit: TextEdit? = nil, additionalTextEdits: [TextEdit]? = nil
 	) {
@@ -33,4 +45,5 @@ public struct ColorPresentation: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/colorPresentation`.
 public typealias ColorPresentationResponse = [ColorPresentation]

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Completion.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Completion.swift
@@ -1,26 +1,52 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/completion` request.
 public struct CompletionClientCapabilities: Codable, Hashable, Sendable {
+	/// Capabilities the client supports related to completion items.
 	public struct CompletionItem: Codable, Hashable, Sendable {
+		/// Resolve support capabilities.
 		public struct ResolveSupport: Codable, Hashable, Sendable {
+			/// The properties that a client can resolve lazily.
 			public var properties: [String]
 
+			/// Creates an instance from its parts.
 			public init(properties: [String]) {
 				self.properties = properties
 			}
 		}
 
+		/// Whether the client supports snippets as insert text.
 		public let snippetSupport: Bool?
+		/// Whether the client supports commit characters on a completion item.
 		public let commitCharactersSupport: Bool?
+		/// The content formats for documentation the client supports.
 		public let documentationFormat: [MarkupKind]?
+		/// Whether the client supports the deprecated property on a completion item.
 		public let deprecatedSupport: Bool?
+		/// Whether the client supports the preselect property on a completion item.
 		public let preselectSupport: Bool?
+		/// The client supports completion item tags.
+		///
+		/// - Since: 3.15.0
 		public var tagSupport: ValueSet<CompletionItemTag>?
+		/// Whether the client supports insert/replace edits.
+		///
+		/// - Since: 3.16.0
 		public var insertReplaceSupport: Bool?
+		/// Indicates which properties a client can resolve lazily.
+		///
+		/// - Since: 3.16.0
 		public var resolveSupport: ResolveSupport?
+		/// The insert text modes the client supports.
+		///
+		/// - Since: 3.16.0
 		public var insertTextModeSupport: ValueSet<InsertTextMode>?
+		/// Whether the client supports label details.
+		///
+		/// - Since: 3.17.0
 		public var labelDetailsSupport: Bool?
 
+		/// Creates an instance from its parts.
 		public init(
 			snippetSupport: Bool? = nil,
 			commitCharactersSupport: Bool? = nil,
@@ -46,21 +72,35 @@ public struct CompletionClientCapabilities: Codable, Hashable, Sendable {
 		}
 	}
 
+	/// Capabilities specific to completion lists.
 	public struct CompletionList: Codable, Hashable, Sendable {
+		/// The client supports item defaults on the completion list.
 		public var itemDefaults: [String]?
 
+		/// Creates an instance from its parts.
 		public init(itemDefaults: [String]? = nil) {
 			self.itemDefaults = itemDefaults
 		}
 	}
 
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// Capabilities for completion items.
 	public var completionItem: CompletionItem?
+	/// The completion item kinds the client supports.
 	public var completionItemKind: ValueSet<CompletionItemKind>?
+	/// Whether the client supports sending additional context information.
 	public var contextSupport: Bool?
+	/// The default insert text mode the client prefers.
+	///
+	/// - Since: 3.17.0
 	public var insertTextMode: InsertTextMode?
+	/// Capabilities for the completion list.
+	///
+	/// - Since: 3.17.0
 	public var completionList: CompletionList?
 
+	/// Creates an instance from its parts.
 	public init(
 		dynamicRegistration: Bool? = nil,
 		completionItem: CompletionItem? = nil,
@@ -78,12 +118,17 @@ public struct CompletionClientCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// How a completion was triggered.
 public enum CompletionTriggerKind: Int, Codable, Hashable, Sendable {
+	/// Completion was triggered by typing an identifier or via API.
 	case invoked = 1
+	/// Completion was triggered by a trigger character.
 	case triggerCharacter = 2
+	/// Completion was re-triggered as the current completion list is incomplete.
 	case triggerForIncompleteCompletions = 3
 }
 
+/// The kind of a completion entry.
 public enum CompletionItemKind: Int, CaseIterable, Codable, Hashable, Sendable {
 	case text = 1
 	case method = 2
@@ -112,25 +157,38 @@ public enum CompletionItemKind: Int, CaseIterable, Codable, Hashable, Sendable {
 	case typeParameter = 25
 }
 
+/// Completion item tags.
+///
+/// - Since: 3.15.0
 public enum CompletionItemTag: Int, CaseIterable, Codable, Hashable, Sendable {
+	/// The completion item is deprecated.
 	case deprecated = 1
 }
 
+/// Contains additional information about the context in which a completion request is triggered.
 public struct CompletionContext: Codable, Hashable, Sendable {
+	/// How the completion was triggered.
 	public let triggerKind: CompletionTriggerKind
+	/// The trigger character that triggered code complete, if `triggerKind` is `triggerCharacter`.
 	public let triggerCharacter: String?
 
+	/// Creates an instance from its parts.
 	public init(triggerKind: CompletionTriggerKind, triggerCharacter: String?) {
 		self.triggerKind = triggerKind
 		self.triggerCharacter = triggerCharacter
 	}
 }
 
+/// Parameters for the `textDocument/completion` request.
 public struct CompletionParams: Codable, Hashable, Sendable {
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public let position: Position
+	/// The completion context.
 	public let context: CompletionContext?
 
+	/// Creates an instance from its parts.
 	public init(
 		textDocument: TextDocumentIdentifier, position: Position, context: CompletionContext?
 	) {
@@ -139,6 +197,7 @@ public struct CompletionParams: Codable, Hashable, Sendable {
 		self.context = context
 	}
 
+	/// Creates an instance from a URI, position, and trigger information.
 	public init(
 		uri: DocumentUri, position: Position, triggerKind: CompletionTriggerKind,
 		triggerCharacter: String?
@@ -150,28 +209,48 @@ public struct CompletionParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// Defines whether the insert text in a completion item should be interpreted as plain text or a snippet.
 public enum InsertTextFormat: Int, Codable, Hashable, Sendable {
+	/// The primary text to be inserted is treated as a plain string.
 	case plaintext = 1
+	/// The primary text to be inserted is treated as a snippet.
 	case snippet = 2
 }
 
+/// A completion item represents a text snippet that is proposed to complete text that is being typed.
 public struct CompletionItem: Codable, Hashable, Sendable {
+	/// The label of this completion item.
 	public let label: String
+	/// The kind of this completion item.
 	public let kind: CompletionItemKind?
+	/// A human-readable string with additional information about this item.
 	public let detail: String?
+	/// A human-readable string that represents a doc-comment.
 	public let documentation: TwoTypeOption<String, MarkupContent>?
+	/// Whether this item is deprecated.
 	public let deprecated: Bool?
+	/// Select this item when showing.
 	public let preselect: Bool?
+	/// A string that should be used when comparing this item with other items.
 	public let sortText: String?
+	/// A string that should be used when filtering a set of completion items.
 	public let filterText: String?
+	/// A string that should be inserted into a document when selecting this completion.
 	public let insertText: String?
+	/// The format of the insert text.
 	public let insertTextFormat: InsertTextFormat?
+	/// An edit which is applied to a document when selecting this completion.
 	public let textEdit: TwoTypeOption<TextEdit, InsertReplaceEdit>?
+	/// Additional text edits applied when selecting this completion.
 	public let additionalTextEdits: [TextEdit]?
+	/// Characters that commit this completion when typed.
 	public let commitCharacters: [String]?
+	/// An optional command that is executed after inserting this completion.
 	public let command: Command?
+	/// A data entry field preserved on a completion item between request rounds.
 	public let data: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(
 		label: String,
 		kind: CompletionItemKind? = nil,
@@ -207,19 +286,25 @@ public struct CompletionItem: Codable, Hashable, Sendable {
 	}
 }
 
+/// Represents a collection of completion items to be presented in the editor.
 public struct CompletionList: Codable, Hashable, Sendable {
+	/// This list is not complete. Further typing should result in recomputing this list.
 	public let isIncomplete: Bool
+	/// The completion items.
 	public let items: [CompletionItem]
 
+	/// Creates an instance from its parts.
 	public init(isIncomplete: Bool, items: [CompletionItem]) {
 		self.isIncomplete = isIncomplete
 		self.items = items
 	}
 }
 
+/// The response type for `textDocument/completion`.
 public typealias CompletionResponse = TwoTypeOption<[CompletionItem], CompletionList>?
 
 extension TwoTypeOption where T == [CompletionItem], U == CompletionList {
+	/// The completion items regardless of the response variant.
 	public var items: [CompletionItem] {
 		switch self {
 		case .optionA(let v):
@@ -229,6 +314,7 @@ extension TwoTypeOption where T == [CompletionItem], U == CompletionList {
 		}
 	}
 
+	/// Whether the completion list is incomplete.
 	public var isIncomplete: Bool {
 		switch self {
 		case .optionA:
@@ -239,11 +325,16 @@ extension TwoTypeOption where T == [CompletionItem], U == CompletionList {
 	}
 }
 
+/// Registration options for completion.
 public struct CompletionRegistrationOptions: Codable {
+	/// A document selector to identify the scope of the registration, if any.
 	public let documentSelector: DocumentSelector?
+	/// The characters that trigger completion automatically, if any.
 	public let triggerCharacters: [String]?
+	/// Whether the server supports resolving additional completion item properties.
 	public let resolveProvider: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		documentSelector: DocumentSelector? = nil,
 		triggerCharacters: [String]? = nil,
@@ -255,7 +346,12 @@ public struct CompletionRegistrationOptions: Codable {
 	}
 }
 
+/// How whitespace and indentation is handled during completion item insertion.
+///
+/// - Since: 3.16.0
 public enum InsertTextMode: Int, CaseIterable, Codable, Hashable, Sendable {
+	/// The insertion or replace strings are taken as-is.
 	case asIs = 1
+	/// The editor adjusts leading whitespace of new lines.
 	case adjustIndentation = 2
 }

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Declaration.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Declaration.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+/// Client capabilities for the `textDocument/declaration` request.
+///
+/// - Since: 3.14.0
 public typealias DeclarationClientCapabilities = DynamicRegistrationLinkSupportClientCapabilities
 
+/// The response type for `textDocument/declaration`.
 public typealias DeclarationResponse = ThreeTypeOption<Location, [Location], [LocationLink]>?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Definition.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Definition.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/definition` request.
 public typealias DefinitionClientCapabilities = DynamicRegistrationLinkSupportClientCapabilities
 
+/// The response type for `textDocument/definition`.
 public typealias DefinitionResponse = ThreeTypeOption<Location, [Location], [LocationLink]>?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Diagnostics.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Diagnostics.swift
@@ -1,11 +1,19 @@
 import Foundation
 
+/// Server capabilities for the diagnostic pull model.
+///
+/// - Since: 3.17.0
 public struct DiagnosticOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public let workDoneProgress: Bool?
+	/// An optional identifier under which the diagnostics are managed.
 	public let identifier: String?
+	/// Whether the language has inter-file dependencies.
 	public let interFileDependencies: Bool
+	/// Whether the server provides workspace diagnostics.
 	public let workspaceDiagnostics: Bool
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneProgress: Bool? = nil, identifier: String? = nil, interFileDependencies: Bool,
 		workspaceDiagnostics: Bool
@@ -17,14 +25,24 @@ public struct DiagnosticOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Registration options for the diagnostic pull model.
+///
+/// - Since: 3.17.0
 public struct DiagnosticRegistrationOptions: Codable, Hashable, Sendable {
+	/// A document selector to identify the scope of the registration, if any.
 	public let documentSelector: DocumentSelector?
+	/// Whether the server supports work done progress.
 	public let workDoneProgress: Bool?
+	/// An optional identifier under which the diagnostics are managed.
 	public let identifier: String?
+	/// Whether the language has inter-file dependencies.
 	public let interFileDependencies: Bool
+	/// Whether the server provides workspace diagnostics.
 	public let workspaceDiagnostics: Bool
+	/// The id used to register the request, if any.
 	public let id: String?
 
+	/// Creates an instance from its parts.
 	public init(
 		documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil,
 		identifier: String? = nil, interFileDependencies: Bool, workspaceDiagnostics: Bool,
@@ -39,13 +57,20 @@ public struct DiagnosticRegistrationOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Client capabilities for `textDocument/publishDiagnostics`.
 public struct PublishDiagnosticsClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether the client supports related information in diagnostics.
 	public var relatedInformation: Bool?
+	/// The client supports diagnostic tags.
 	public var tagSupport: ValueSet<DiagnosticTag>?
+	/// Whether the client interprets the version property of diagnostics.
 	public var versionSupport: Bool?
+	/// Whether the client supports `codeDescription` on diagnostics.
 	public var codeDescriptionSupport: Bool?
+	/// Whether the client supports the `data` property on diagnostics.
 	public var dataSupport: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		relatedInformation: Bool? = nil, tagSupport: ValueSet<DiagnosticTag>? = nil,
 		versionSupport: Bool? = nil, codeDescriptionSupport: Bool? = nil, dataSupport: Bool? = nil
@@ -58,58 +83,98 @@ public struct PublishDiagnosticsClientCapabilities: Codable, Hashable, Sendable 
 	}
 }
 
+/// Client capabilities for the diagnostic pull model.
+///
+/// - Since: 3.17.0
 public struct DiagnosticClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// Whether the client supports related document diagnostics.
 	public var relatedDocumentSupport: Bool?
 
+	/// Creates an instance from its parts.
 	public init(dynamicRegistration: Bool? = nil, relatedDocumentSupport: Bool?) {
 		self.dynamicRegistration = dynamicRegistration
 		self.relatedDocumentSupport = relatedDocumentSupport
 	}
 }
 
+/// Represents a related message and source code location for a diagnostic.
 public struct DiagnosticRelatedInformation: Codable, Hashable, Sendable {
+	/// The location of this related diagnostic information.
 	public let location: Location
+	/// The message of this related diagnostic information.
 	public let message: String
 
+	/// Creates an instance from its parts.
 	public init(location: Location, message: String) {
 		self.location = location
 		self.message = message
 	}
 }
 
+/// The diagnostic's code, which might appear in the user interface.
 public typealias DiagnosticCode = TwoTypeOption<Int, String>
 
+/// The diagnostic's severity.
 public enum DiagnosticSeverity: Int, CaseIterable, Codable, Hashable, Sendable {
+	/// Reports an error.
 	case error = 1
+	/// Reports a warning.
 	case warning = 2
+	/// Reports an information.
 	case information = 3
+	/// Reports a hint.
 	case hint = 4
 }
 
+/// The diagnostic tags.
+///
+/// - Since: 3.15.0
 public enum DiagnosticTag: Int, CaseIterable, Codable, Hashable, Sendable {
+	/// Unused or unnecessary code.
 	case unnecessary = 1
+	/// Deprecated or obsolete code.
 	case deprecated = 2
 }
 
+/// Structure to capture a description for an error code.
+///
+/// - Since: 3.16.0
 public struct CodeDescription: Codable, Hashable, Sendable {
+	/// An URI to open with more information about the diagnostic error.
 	public let href: URI
 
+	/// Creates an instance from its parts.
 	public init(href: URI) {
 		self.href = href
 	}
 }
 
+/// Represents a diagnostic, such as a compiler error or warning.
 public struct Diagnostic: Codable, Hashable, Sendable {
+	/// The range at which the message applies.
 	public let range: LSPRange
+	/// The diagnostic's severity.
 	public let severity: DiagnosticSeverity?
+	/// The diagnostic's code.
 	public let code: DiagnosticCode?
+	/// An optional property to describe the error code.
+	///
+	/// - Since: 3.16.0
 	public let codeDescription: CodeDescription?
+	/// A human-readable string describing the source of this diagnostic.
 	public let source: String?
+	/// The diagnostic's message.
 	public let message: String
+	/// Additional metadata about the diagnostic.
+	///
+	/// - Since: 3.15.0
 	public let tags: [DiagnosticTag]?
+	/// An array of related diagnostic information.
 	public let relatedInformation: [DiagnosticRelatedInformation]?
 
+	/// Creates an instance from its parts.
 	public init(
 		range: LSPRange, severity: DiagnosticSeverity? = nil, code: DiagnosticCode? = nil,
 		codeDescription: CodeDescription? = nil, source: String? = nil, message: String,
@@ -126,11 +191,16 @@ public struct Diagnostic: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/publishDiagnostics` notification.
 public struct PublishDiagnosticsParams: Codable, Hashable, Sendable {
+	/// The URI for which diagnostic information is reported.
 	public let uri: DocumentUri
+	/// The version number of the document the diagnostics are published for.
 	public let version: Int?
+	/// An array of diagnostic information items.
 	public let diagnostics: [Diagnostic]
 
+	/// Creates an instance from its parts.
 	public init(uri: DocumentUri, version: Int? = nil, diagnostics: [Diagnostic]) {
 		self.uri = uri
 		self.version = version
@@ -138,13 +208,22 @@ public struct PublishDiagnosticsParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/diagnostic` request.
+///
+/// - Since: 3.17.0
 public struct DocumentDiagnosticParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public let partialResultToken: ProgressToken?
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The additional identifier provided during registration, if any.
 	public let identifier: String?
+	/// The result id of a previous response, if known.
 	public let previousResultId: String?
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneToken: ProgressToken? = nil,
 		partialResultToken: ProgressToken? = nil,
@@ -160,16 +239,26 @@ public struct DocumentDiagnosticParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// The document diagnostic report kind.
+///
+/// - Since: 3.17.0
 public enum DocumentDiagnosticReportKind: String, Codable, Hashable, Sendable, CaseIterable {
+	/// A full document diagnostic report.
 	case full
+	/// An unchanged document diagnostic report.
 	case unchanged
 }
 
+/// A base document diagnostic report.
 public struct BaseDocumentDiagnosticReport: Codable, Hashable, Sendable {
+	/// The kind of this diagnostic report.
 	public let kind: DocumentDiagnosticReportKind
+	/// An optional result id, if any.
 	public let resultId: String?
+	/// The actual diagnostic items, if any.
 	public let items: [Diagnostic]?
 
+	/// Creates an instance from its parts.
 	public init(
 		kind: DocumentDiagnosticReportKind, resultId: String? = nil, items: [Diagnostic]? = nil
 	) {
@@ -179,12 +268,18 @@ public struct BaseDocumentDiagnosticReport: Codable, Hashable, Sendable {
 	}
 }
 
+/// A diagnostic report with additional related document information.
 public struct RelatedDocumentDiagnosticReport: Codable, Hashable, Sendable {
+	/// The kind of this diagnostic report.
 	public let kind: DocumentDiagnosticReportKind
+	/// An optional result id, if any.
 	public let resultId: String?
+	/// The actual diagnostic items, if any.
 	public let items: [Diagnostic]?
+	/// Diagnostics of related documents, if any.
 	public let relatedDocuments: [DocumentUri: DocumentDiagnosticReport]?
 
+	/// Creates an instance from its parts.
 	public init(
 		kind: DocumentDiagnosticReportKind, resultId: String? = nil, items: [Diagnostic]? = nil,
 		relatedDocuments: [DocumentUri: DocumentDiagnosticReport]? = nil
@@ -201,4 +296,5 @@ typealias UnchangedDocumentDiagnosticReport = BaseDocumentDiagnosticReport
 typealias RelatedFullDocumentDiagnosticReport = RelatedDocumentDiagnosticReport
 typealias RelatedUnchangedDocumentDiagnosticReport = RelatedDocumentDiagnosticReport
 
+/// The response type for `textDocument/diagnostic`.
 public typealias DocumentDiagnosticReport = RelatedDocumentDiagnosticReport

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentColor.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentColor.swift
@@ -1,12 +1,18 @@
 import Foundation
 
+/// Client capabilities for the document color feature.
 public typealias DocumentColorClientCapabilities = DynamicRegistrationClientCapabilities
 
+/// Parameters for the `textDocument/documentColor` request.
 public struct DocumentColorParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public let partialResultToken: ProgressToken?
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
 
+	/// Creates an instance from its parts.
 	public init(
 		textDocument: TextDocumentIdentifier, workDoneToken: ProgressToken? = nil,
 		partialResultToken: ProgressToken? = nil
@@ -17,12 +23,18 @@ public struct DocumentColorParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// Represents a color in RGBA space.
 public struct Color: Codable, Hashable, Sendable {
+	/// The red component in the range [0, 1].
 	public let red: Float
+	/// The green component in the range [0, 1].
 	public let green: Float
+	/// The blue component in the range [0, 1].
 	public let blue: Float
+	/// The alpha component in the range [0, 1].
 	public let alpha: Float
 
+	/// Creates an instance from its parts.
 	public init(red: Float, green: Float, blue: Float, alpha: Float) {
 		self.red = red
 		self.green = green
@@ -31,14 +43,19 @@ public struct Color: Codable, Hashable, Sendable {
 	}
 }
 
+/// Represents a color range from a document.
 public struct ColorInformation: Codable, Hashable, Sendable {
+	/// The range in the document where this color appears.
 	public let range: LSPRange
+	/// The actual color value for this color range.
 	public let color: Color
 
+	/// Creates an instance from its parts.
 	public init(range: LSPRange, color: Color) {
 		self.range = range
 		self.color = color
 	}
 }
 
+/// The response type for `textDocument/documentColor`.
 public typealias DocumentColorResponse = [ColorInformation]

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentHighlight.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentHighlight.swift
@@ -1,13 +1,19 @@
 import Foundation
 
+/// Client capabilities for the document highlight feature.
 public typealias DocumentHighlightClientCapabilities = DynamicRegistrationClientCapabilities
 
+/// Server capabilities for the document highlight feature.
 public typealias DocumentHighlightOptions = WorkDoneProgressOptions
 
+/// Registration options for document highlight.
 public struct DocumentHighlightRegistrationOptions: Codable, Hashable, Sendable {
+	/// A document selector to identify the scope of the registration, if any.
 	public var documentSelector: DocumentSelector?
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil
 	) {
@@ -16,12 +22,18 @@ public struct DocumentHighlightRegistrationOptions: Codable, Hashable, Sendable 
 	}
 }
 
+/// Parameters for the `textDocument/documentHighlight` request.
 public struct DocumentHighlightParams: Codable, Hashable, Sendable {
+	/// The text document.
 	public var textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public var position: Position
+	/// An optional token for work done progress.
 	public var workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public var partialResultToken: ProgressToken?
 
+	/// Creates an instance from its parts.
 	public init(
 		textDocument: TextDocumentIdentifier, position: Position,
 		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil
@@ -33,16 +45,24 @@ public struct DocumentHighlightParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// A document highlight kind.
 public enum DocumentHighlightKind: Int, CaseIterable, Codable, Hashable, Sendable {
+	/// A textual occurrence.
 	case Text = 1
+	/// Read-access of a symbol.
 	case Read = 2
+	/// Write-access of a symbol.
 	case Write = 3
 }
 
+/// A document highlight is a range inside a text document that deserves special attention.
 public struct DocumentHighlight: Codable, Hashable, Sendable {
+	/// The range this highlight applies to.
 	public var range: LSPRange
+	/// The highlight kind, defaults to text.
 	public var kind: DocumentHighlightKind?
 
+	/// Creates an instance from its parts.
 	public init(
 		range: LSPRange, kind: DocumentHighlightKind? = nil
 	) {
@@ -51,4 +71,5 @@ public struct DocumentHighlight: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/documentHighlight`.
 public typealias DocumentHighlightResponse = [DocumentHighlight]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentLink.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentLink.swift
@@ -7,31 +7,46 @@
 
 import Foundation
 
+/// Client capabilities for the document link feature.
 public struct DocumentLinkClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// Whether the client supports tooltips on document links.
+	///
+	/// - Since: 3.15.0
 	public var tooltipSupport: Bool?
 
+	/// Creates an instance from its parts.
 	public init(dynamicRegistration: Bool, tooltipSupport: Bool? = nil) {
 		self.dynamicRegistration = dynamicRegistration
 		self.tooltipSupport = tooltipSupport
 	}
 }
 
+/// Server capabilities for the document link feature.
 public struct DocumentLinkOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// Whether the server supports resolving additional document link properties.
 	public var resolveProvider: Bool?
 
+	/// Creates an instance from its parts.
 	public init(workDoneProgress: Bool? = nil, resolveProvider: Bool? = nil) {
 		self.workDoneProgress = workDoneProgress
 		self.resolveProvider = resolveProvider
 	}
 }
 
+/// Registration options for document link.
 public struct DocumentLinkRegistrationOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// A document selector to identify the scope of the registration, if any.
 	public var documentSelector: DocumentSelector?
+	/// Whether the server supports resolving additional document link properties.
 	public var resolveProvider: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneProgress: Bool? = nil, documentSelector: DocumentSelector? = nil,
 		resolveProvider: Bool? = nil
@@ -42,10 +57,14 @@ public struct DocumentLinkRegistrationOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/documentLink` request.
 public struct DocumentLinkParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public var workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public var partialResultToken: ProgressToken?
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil
 	) {
@@ -54,12 +73,20 @@ public struct DocumentLinkParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// A document link is a range in a text document that links to an internal or external resource.
 public struct DocumentLink: Codable, Hashable, Sendable {
+	/// The range this link applies to.
 	public var range: LSPRange
+	/// The URI this link points to.
 	public var target: DocumentUri?
+	/// The tooltip text when hovering over this link.
+	///
+	/// - Since: 3.15.0
 	public var tooltip: String?
+	/// A data entry field that is preserved on a document link between request rounds.
 	public var data: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(range: LSPRange, target: DocumentUri?, tooltip: String?, data: LSPAny?) {
 		self.range = range
 		self.target = target
@@ -68,4 +95,5 @@ public struct DocumentLink: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/documentLink`.
 public typealias DocumentLinkResponse = [DocumentLink]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/DocumentSymbol.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/DocumentSymbol.swift
@@ -1,12 +1,21 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/documentSymbol` request.
 public struct DocumentSymbolClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// The symbol kinds the client supports.
 	public var symbolKind: ValueSet<SymbolKind>?
+	/// Whether the client supports hierarchical document symbols.
 	public var hierarchicalDocumentSymbolSupport: Bool?
+	/// The client supports symbol tags.
+	///
+	/// - Since: 3.16.0
 	public var tagSupport: ValueSet<SymbolTag>?
+	/// Whether the client supports the `label` property on document symbols.
 	public var labelSupport: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		dynamicRegistration: Bool, symbolKind: ValueSet<SymbolKind>? = nil,
 		hierarchicalDocumentSymbolSupport: Bool? = nil, tagSupport: ValueSet<SymbolTag>? = nil,
@@ -20,15 +29,20 @@ public struct DocumentSymbolClientCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/documentSymbol` request.
 public struct DocumentSymbolParams: Codable, Hashable, Sendable {
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier) {
 		self.textDocument = textDocument
 	}
 }
 
+/// Represents programming constructs like variables, classes, interfaces etc. in a document.
 public struct DocumentSymbol: Codable, Hashable, Sendable {
+	/// Creates an instance from its parts.
 	public init(
 		name: String, detail: String? = nil, kind: SymbolKind, deprecated: Bool? = nil,
 		range: LSPRange, selectionRange: LSPRange, children: [DocumentSymbol]? = nil
@@ -42,13 +56,21 @@ public struct DocumentSymbol: Codable, Hashable, Sendable {
 		self.children = children
 	}
 
+	/// The name of this symbol.
 	public let name: String
+	/// More detail for this symbol, e.g. the signature of a function.
 	public let detail: String?
+	/// The kind of this symbol.
 	public let kind: SymbolKind
+	/// Whether the symbol is deprecated.
 	public let deprecated: Bool?
+	/// The range enclosing this symbol.
 	public let range: LSPRange
+	/// The range that should be selected and revealed when this symbol is being picked.
 	public let selectionRange: LSPRange
+	/// Children of this symbol, e.g. properties of a class.
 	public let children: [DocumentSymbol]?
 }
 
+/// The response type for `textDocument/documentSymbol`.
 public typealias DocumentSymbolResponse = TwoTypeOption<[DocumentSymbol], [SymbolInformation]>?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/FoldingRange.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/FoldingRange.swift
@@ -1,10 +1,15 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/foldingRange` request.
 public struct FoldingRangeClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// The maximum number of folding ranges the client supports.
 	public var rangeLimit: Int?
+	/// Whether the client only supports folding complete lines.
 	public var lineFoldingOnly: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		dynamicRegistration: Bool? = nil, rangeLimit: Int? = nil, lineFoldingOnly: Bool? = nil
 	) {
@@ -14,27 +19,41 @@ public struct FoldingRangeClientCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/foldingRange` request.
 public struct FoldingRangeParams: Codable, Hashable, Sendable {
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier) {
 		self.textDocument = textDocument
 	}
 }
 
+/// The kind of a folding range.
 public enum FoldingRangeKind: String, CaseIterable, Codable, Hashable, Sendable {
+	/// Folding range for a comment.
 	case comment
+	/// Folding range for imports or includes.
 	case imports
+	/// Folding range for a region.
 	case region
 }
 
+/// Represents a folding range.
 public struct FoldingRange: Codable, Hashable, Sendable {
+	/// The zero-based start line of the range to fold.
 	public let startLine: Int
+	/// The zero-based character offset from where the folded range starts.
 	public let startCharacter: Int?
+	/// The zero-based end line of the range to fold.
 	public let endLine: Int
+	/// The zero-based character offset before the folded range ends.
 	public let endCharacter: Int?
+	/// Describes the kind of the folding range.
 	public let kind: FoldingRangeKind?
 
+	/// Creates an instance from its parts.
 	public init(
 		startLine: Int, startCharacter: Int? = nil, endLine: Int,
 		endCharacter: Int? = nil, kind: FoldingRangeKind? = nil
@@ -47,4 +66,5 @@ public struct FoldingRange: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/foldingRange`.
 public typealias FoldingRangeResponse = [FoldingRange]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Formatting.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Formatting.swift
@@ -1,33 +1,48 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/formatting` request.
 public typealias DocumentFormattingClientCapabilities = DynamicRegistrationClientCapabilities
+/// Client capabilities for the `textDocument/rangeFormatting` request.
 public typealias DocumentRangeFormattingClientCapabilities = DynamicRegistrationClientCapabilities
 
+/// Value-object describing what formatting options are available.
 public struct FormattingOptions: Codable, Hashable, Sendable {
+	/// Size of a tab in spaces.
 	public let tabSize: Int
+	/// Prefer spaces over tabs.
 	public let insertSpaces: Bool
 
+	/// Creates an instance from its parts.
 	public init(tabSize: Int, insertSpaces: Bool) {
 		self.tabSize = tabSize
 		self.insertSpaces = insertSpaces
 	}
 }
 
+/// Parameters for the `textDocument/formatting` request.
 public struct DocumentFormattingParams: Codable, Hashable, Sendable {
+	/// The document to format.
 	public let textDocument: TextDocumentIdentifier
+	/// The format options.
 	public let options: FormattingOptions
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier, options: FormattingOptions) {
 		self.textDocument = textDocument
 		self.options = options
 	}
 }
 
+/// Parameters for the `textDocument/rangeFormatting` request.
 public struct DocumentRangeFormattingParams: Codable, Hashable, Sendable {
+	/// The document to format.
 	public let textDocument: TextDocumentIdentifier
+	/// The range to format.
 	public let range: LSPRange
+	/// The format options.
 	public let options: FormattingOptions
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier, range: LSPRange, options: FormattingOptions) {
 		self.textDocument = textDocument
 		self.range = range
@@ -35,12 +50,18 @@ public struct DocumentRangeFormattingParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/onTypeFormatting` request.
 public struct DocumentOnTypeFormattingParams: Codable, Hashable, Sendable {
+	/// The document to format.
 	public let textDocument: TextDocumentIdentifier
+	/// The position at which this request was sent.
 	public let position: Position
+	/// The character that has been typed.
 	public let ch: String
+	/// The format options.
 	public let options: FormattingOptions
 
+	/// Creates an instance from its parts.
 	public init(
 		textDocument: TextDocumentIdentifier, position: Position, ch: String,
 		options: FormattingOptions
@@ -52,4 +73,5 @@ public struct DocumentOnTypeFormattingParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for formatting requests.
 public typealias FormattingResult = [TextEdit]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Hover.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Hover.swift
@@ -1,19 +1,27 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/hover` request.
 public struct HoverClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// The content formats the client supports for hover results.
 	public var contentFormat: [MarkupKind]?
 
+	/// Creates an instance from its parts.
 	public init(dynamicRegistration: Bool?, contentFormat: [MarkupKind]?) {
 		self.dynamicRegistration = dynamicRegistration
 		self.contentFormat = contentFormat
 	}
 }
 
+/// The result of a hover request.
 public struct Hover: Codable, Hashable, Sendable {
+	/// The hover's content.
 	public let contents: ThreeTypeOption<MarkedString, [MarkedString], MarkupContent>
+	/// An optional range that applies to the hover.
 	public let range: LSPRange?
 
+	/// Creates an instance from its parts.
 	public init(
 		contents: ThreeTypeOption<MarkedString, [MarkedString], MarkupContent>, range: LSPRange?
 	) {
@@ -21,10 +29,12 @@ public struct Hover: Codable, Hashable, Sendable {
 		self.range = range
 	}
 
+	/// Creates an instance from a plain string.
 	public init(contents: String, range: LSPRange? = nil) {
 		self.contents = .optionA(.optionA(contents))
 		self.range = range
 	}
 }
 
+/// The response type for `textDocument/hover`.
 public typealias HoverResponse = Hover?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Implementation.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Implementation.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// The response type for `textDocument/implementation`.
 public typealias ImplementationResponse = ThreeTypeOption<Location, [Location], [LocationLink]>?
 
+/// Client capabilities for the `textDocument/implementation` request.
 public typealias ImplementationClientCapabilities = DynamicRegistrationLinkSupportClientCapabilities

--- a/Sources/LanguageServerProtocol/LanguageFeatures/InlayHint.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/InlayHint.swift
@@ -1,29 +1,48 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/inlayHint` request.
+///
+/// - Since: 3.17.0
 public struct InlayHintClientCapabilities: Codable, Hashable, Sendable {
+	/// Resolve support capabilities.
 	public struct ResolveSupport: Codable, Hashable, Sendable {
+		/// The properties that a client can resolve lazily.
 		public var properties: [String]
 
+		/// Creates an instance from its parts.
 		public init(properties: [String]) {
 			self.properties = properties
 		}
 	}
 
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// Indicates which properties a client can resolve lazily.
 	public var resolveSupport: ResolveSupport?
 
+	/// Creates an instance from its parts.
 	public init(dynamicRegistration: Bool?, resolveSupport: ResolveSupport? = nil) {
 		self.dynamicRegistration = dynamicRegistration
 	}
 }
 
+/// Server capabilities for the inlay hint feature.
+///
+/// - Since: 3.17.0
 public typealias InlayHintOptions = WorkDoneProgressOptions
 
+/// Registration options for inlay hints.
+///
+/// - Since: 3.17.0
 public struct InlayHintRegistrationOptions: Codable, Hashable, Sendable {
+	/// A document selector to identify the scope of the registration, if any.
 	public var documentSelector: DocumentSelector?
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// The id used to register the request, if any.
 	public var id: String?
 
+	/// Creates an instance from its parts.
 	public init(
 		documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil, id: String? = nil
 	) {
@@ -33,19 +52,31 @@ public struct InlayHintRegistrationOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Workspace client capabilities specific to inlay hints.
+///
+/// - Since: 3.17.0
 public struct InlayHintWorkspaceClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether the client supports a refresh request sent from the server.
 	public var refreshSupport: Bool?
 
+	/// Creates an instance from its parts.
 	public init(refreshSupport: Bool? = nil) {
 		self.refreshSupport = refreshSupport
 	}
 }
 
+/// Parameters for the `textDocument/inlayHint` request.
+///
+/// - Since: 3.17.0
 public struct InlayHintParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public var workDoneToken: ProgressToken?
+	/// The text document.
 	public var textDocument: TextDocumentIdentifier
+	/// The visible document range for which inlay hints should be computed.
 	public var range: LSPRange
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneToken: ProgressToken? = nil, textDocument: TextDocumentIdentifier, range: LSPRange
 	) {
@@ -55,12 +86,20 @@ public struct InlayHintParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// An inlay hint label part allows for interactive and composite labels.
+///
+/// - Since: 3.17.0
 public struct InlayHintLabelPart: Codable, Hashable, Sendable {
+	/// The value of this label part.
 	public var value: String
+	/// The tooltip text when hovering over this label part.
 	public var tooltip: TwoTypeOption<String, MarkupContent>?
+	/// An optional source code location that represents this label part.
 	public var location: Location?
+	/// An optional command for this label part.
 	public var command: Command?
 
+	/// Creates an instance from its parts.
 	public init(
 		value: String, tooltip: TwoTypeOption<String, MarkupContent>? = nil,
 		location: Location? = nil, command: Command? = nil
@@ -72,21 +111,38 @@ public struct InlayHintLabelPart: Codable, Hashable, Sendable {
 	}
 }
 
+/// Inlay hint kinds.
+///
+/// - Since: 3.17.0
 public enum InlayHintKind: Int, Codable, Hashable, Sendable {
+	/// An inlay hint that is for a type annotation.
 	case type = 1
+	/// An inlay hint that is for a parameter.
 	case parameter = 2
 }
 
+/// Inlay hint information.
+///
+/// - Since: 3.17.0
 public struct InlayHint: Codable, Hashable, Sendable {
+	/// The position of this hint.
 	public var position: Position
+	/// The label of this hint.
 	public var label: TwoTypeOption<String, [InlayHintLabelPart]>
+	/// The kind of this hint.
 	public var kind: InlayHintKind?
+	/// Optional text edits applied when accepting this inlay hint.
 	public var textEdits: [TextEdit]?
+	/// The tooltip text when hovering over this item.
 	public var tooltip: TwoTypeOption<String, MarkupContent>?
+	/// Render padding before the hint.
 	public var paddingLeft: Bool?
+	/// Render padding after the hint.
 	public var paddingRight: Bool?
+	/// A data entry field preserved on an inlay hint between request rounds.
 	public var data: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(
 		position: Position,
 		label: TwoTypeOption<String, [InlayHintLabelPart]>,
@@ -108,4 +164,5 @@ public struct InlayHint: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/inlayHint`.
 public typealias InlayHintResponse = [InlayHint]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/LinkedEditingRange.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/LinkedEditingRange.swift
@@ -1,14 +1,25 @@
 import Foundation
 
+/// Client capabilities for the linked editing range feature.
+///
+/// - Since: 3.16.0
 public typealias LinkedEditingRangeClientCapabilities = DynamicRegistrationClientCapabilities
 
+/// Parameters for the `textDocument/linkedEditingRange` request.
+///
+/// - Since: 3.16.0
 public struct LinkedEditingRangeParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public let partialResultToken: ProgressToken?
 
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public let position: Position
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil,
 		textDocument: TextDocumentIdentifier, position: Position
@@ -20,14 +31,21 @@ public struct LinkedEditingRangeParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// The result of a linked editing range request.
+///
+/// - Since: 3.16.0
 public struct LinkedEditingRanges: Codable, Sendable {
+	/// A list of ranges that can be renamed together.
 	public let ranges: [LSPRange]
+	/// An optional word pattern to describe valid contents for the ranges.
 	public let wordPattern: String?
 
+	/// Creates an instance from its parts.
 	public init(ranges: [LSPRange], wordPattern: String? = nil) {
 		self.ranges = ranges
 		self.wordPattern = wordPattern
 	}
 }
 
+/// The response type for `textDocument/linkedEditingRange`.
 public typealias LinkedEditingRangeResponse = LinkedEditingRanges?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Moniker.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Moniker.swift
@@ -1,14 +1,25 @@
 import Foundation
 
+/// Client capabilities for the moniker feature.
+///
+/// - Since: 3.16.0
 public typealias MonikerClientCapabilities = DynamicRegistrationClientCapabilities
 
+/// Parameters for the `textDocument/moniker` request.
+///
+/// - Since: 3.16.0
 public struct MonikerParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public let partialResultToken: ProgressToken?
 
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public let position: Position
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil,
 		textDocument: TextDocumentIdentifier, position: Position
@@ -20,25 +31,47 @@ public struct MonikerParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// The moniker uniqueness level.
+///
+/// - Since: 3.16.0
 public enum UniquenessLevel: Codable, Sendable {
+	/// The moniker is only unique inside a document.
 	case document
+	/// The moniker is unique inside a project.
 	case project
+	/// The moniker is unique inside the group to which a project belongs.
 	case group
+	/// The moniker is unique inside the moniker scheme.
 	case scheme
+	/// The moniker is globally unique.
 	case global
 }
 
+/// The moniker kind.
+///
+/// - Since: 3.16.0
 public enum MonikerKind: Codable, Sendable {
+	/// The moniker represents a symbol imported into a project.
 	case _import
+	/// The moniker represents a symbol exported from a project.
 	case export
+	/// The moniker represents a symbol local to a project.
 	case local
 }
 
+/// Moniker definition to match LSIF 0.5 moniker definition.
+///
+/// - Since: 3.16.0
 public struct Moniker: Codable, Sendable {
+	/// The scheme of the moniker.
 	public let scheme: String
+	/// The identifier of the moniker.
 	public let identifier: String
+	/// The scope in which the moniker is unique.
 	public let unique: UniquenessLevel
+	/// The moniker kind, if known.
 	public let kind: MonikerKind?
 }
 
+/// The response type for `textDocument/moniker`.
 public typealias MonikerResponse = [Moniker]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/OnTypeFormatting.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/OnTypeFormatting.swift
@@ -1,3 +1,4 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/onTypeFormatting` request.
 public typealias DocumentOnTypeFormattingClientCapabilities = DynamicRegistrationClientCapabilities

--- a/Sources/LanguageServerProtocol/LanguageFeatures/References.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/References.swift
@@ -1,20 +1,29 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/references` request.
 public typealias ReferenceClientCapabilities = DynamicRegistrationClientCapabilities
 
+/// Context for the `textDocument/references` request.
 public struct ReferenceContext: Codable, Hashable, Sendable {
+	/// Include the declaration of the current symbol.
 	public let includeDeclaration: Bool
 
+	/// Creates an instance from its parts.
 	public init(includeDeclaration: Bool) {
 		self.includeDeclaration = includeDeclaration
 	}
 }
 
+/// Parameters for the `textDocument/references` request.
 public struct ReferenceParams: Codable, Hashable, Sendable {
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public let position: Position
+	/// The reference context.
 	public let context: ReferenceContext
 
+	/// Creates an instance from its parts.
 	public init(
 		textDocument: TextDocumentIdentifier, position: Position,
 		context: ReferenceContext
@@ -24,6 +33,7 @@ public struct ReferenceParams: Codable, Hashable, Sendable {
 		self.context = context
 	}
 
+	/// Creates an instance with an `includeDeclaration` flag.
 	public init(
 		textDocument: TextDocumentIdentifier, position: Position, includeDeclaration: Bool = false
 	) {
@@ -33,4 +43,5 @@ public struct ReferenceParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/references`.
 public typealias ReferenceResponse = [Location]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/Rename.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Rename.swift
@@ -1,15 +1,29 @@
 import Foundation
 
+/// The default behavior for prepare rename.
+///
+/// - Since: 3.16.0
 public enum PrepareSupportDefaultBehavior: Int, CaseIterable, Codable, Hashable, Sendable {
+	/// The client's default behavior is to select the identifier according to the language's syntax rule.
 	case Identifier = 1
 }
 
+/// Client capabilities for the `textDocument/rename` request.
 public struct RenameClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether dynamic registration is supported.
 	public let dynamicRegistration: Bool?
+	/// Whether the client supports testing for validity of rename operations before execution.
 	public let prepareSupport: Bool?
+	/// The client's default behavior when no result-specific behavior is defined.
+	///
+	/// - Since: 3.16.0
 	public let prepareSupportDefaultBehavior: PrepareSupportDefaultBehavior?
+	/// Whether the client honors change annotations.
+	///
+	/// - Since: 3.16.0
 	public let honorsChangeAnnotations: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		dynamicRegistration: Bool?, prepareSupport: Bool?,
 		prepareSupportDefaultBehavior: PrepareSupportDefaultBehavior?,
@@ -22,23 +36,33 @@ public struct RenameClientCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// Server capabilities for the rename feature.
 public struct RenameOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// Whether renames should be checked and tested before being executed.
 	public var prepareProvider: Bool?
 
+	/// Creates an instance from its parts.
 	public init(workDoneProgress: Bool? = nil, prepareProvider: Bool? = nil) {
 		self.workDoneProgress = workDoneProgress
 		self.prepareProvider = prepareProvider
 	}
 }
 
+/// Parameters for the `textDocument/prepareRename` request.
 public typealias PrepareRenameParams = TextDocumentPositionParams
 
+/// Parameters for the `textDocument/rename` request.
 public struct RenameParams: Codable, Hashable, Sendable {
+	/// The document to rename.
 	public let textDocument: TextDocumentIdentifier
+	/// The position at which this request was sent.
 	public let position: Position
+	/// The new name of the symbol.
 	public let newName: String
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier, position: Position, newName: String) {
 		self.textDocument = textDocument
 		self.position = position
@@ -46,26 +70,35 @@ public struct RenameParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// A range with a placeholder for rename.
 public struct RangeWithPlaceholder: Codable, Hashable, Sendable {
+	/// The range of the string to rename.
 	public let range: LSPRange
+	/// A placeholder text of the string content to be renamed.
 	public let placeholder: String
 
+	/// Creates an instance from its parts.
 	public init(range: LSPRange, placeholder: String) {
 		self.range = range
 		self.placeholder = placeholder
 	}
 }
 
+/// Indicates the default behavior for prepare rename.
 public struct PrepareRenameDefaultBehavior: Codable, Hashable, Sendable {
+	/// Whether the default behavior is to be used.
 	public let defaultBehavior: Bool
 
+	/// Creates an instance from its parts.
 	public init(defaultBehavior: Bool) {
 		self.defaultBehavior = defaultBehavior
 	}
 }
 
+/// The response type for `textDocument/prepareRename`.
 public typealias PrepareRenameResponse = ThreeTypeOption<
 	LSPRange, RangeWithPlaceholder, PrepareRenameDefaultBehavior
 >?
 
+/// The response type for `textDocument/rename`.
 public typealias RenameResponse = WorkspaceEdit?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/SelectionRange.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/SelectionRange.swift
@@ -1,18 +1,35 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/selectionRange` request.
+///
+/// - Since: 3.15.0
 public typealias SelectionRangeClientCapabilities = DynamicRegistrationClientCapabilities
 
+/// Server capabilities for the selection range feature.
+///
+/// - Since: 3.15.0
 public typealias SelectionRangeOptions = WorkDoneProgressOptions
 
+/// Registration options for selection range.
+///
+/// - Since: 3.15.0
 public typealias SelectionRangeRegistrationOptions =
 	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
+/// Parameters for the `textDocument/selectionRange` request.
+///
+/// - Since: 3.15.0
 public struct SelectionRangeParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public let partialResultToken: ProgressToken?
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The positions inside the text document.
 	public let positions: [Position]
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil,
 		textDocument: TextDocumentIdentifier, positions: [Position]
@@ -24,10 +41,16 @@ public struct SelectionRangeParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// A selection range represents a part of a selection hierarchy.
+///
+/// - Since: 3.15.0
 public final class SelectionRange: Codable, Sendable {
+	/// The range of this selection range.
 	public let range: LSPRange
+	/// The parent selection range containing this range.
 	public let parent: SelectionRange?
 
+	/// Creates an instance from its parts.
 	public init(range: LSPRange, parent: SelectionRange?) {
 		self.range = range
 		self.parent = parent
@@ -40,4 +63,5 @@ extension SelectionRange: Equatable {
 	}
 }
 
+/// The response type for `textDocument/selectionRange`.
 public typealias SelectionRangeResponse = [SelectionRange]?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/SemanticTokens.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/SemanticTokens.swift
@@ -1,54 +1,87 @@
 import Foundation
 
+/// Workspace client capabilities specific to semantic tokens.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensWorkspaceClientCapabilities: Codable, Hashable, Sendable {
+	/// Whether the client supports a refresh request sent from the server.
 	public var refreshSupport: Bool?
 
+	/// Creates an instance from its parts.
 	public init(refreshSupport: Bool) {
 		self.refreshSupport = refreshSupport
 	}
 }
 
+/// The token format.
+///
+/// - Since: 3.16.0
 public enum TokenFormat: String, Codable, Hashable, Sendable {
+	/// Tokens are encoded relative to each other.
 	case relative = "relative"
 
+	/// Relative token format.
 	public static let Relative = TokenFormat.relative
 }
 
+/// Client capabilities for the `textDocument/semanticTokens` request.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensClientCapabilities: Codable, Hashable, Sendable {
+	/// Which requests the client supports.
 	public struct Requests: Codable, Hashable, Sendable {
+		/// Range request support.
 		public struct Range: Codable, Hashable, Sendable {
 		}
 
+		/// Full request support.
 		public struct Full: Codable, Hashable, Sendable {
+			/// Whether the client supports delta updates for full requests.
 			public var delta: Bool?
 
+			/// Creates an instance from its parts.
 			public init(delta: Bool = true) {
 				self.delta = delta
 			}
 		}
 
+		/// A union representing range request support.
 		public typealias RangeOption = TwoTypeOption<Bool, Range>
+		/// A union representing full request support.
 		public typealias FullOption = TwoTypeOption<Bool, Full>
 
+		/// Whether range requests are supported.
 		public var range: RangeOption?
+		/// Whether full document requests are supported.
 		public var full: FullOption?
 
+		/// Creates an instance from its parts.
 		public init(range: Bool = true, delta: Bool = true) {
 			self.range = .optionA(range)
 			self.full = .optionB(Full(delta: true))
 		}
 	}
 
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// Which requests the client supports and might send.
 	public var requests: Requests
+	/// The token types that the client supports.
 	public var tokenTypes: [String]
+	/// The token modifiers that the client supports.
 	public var tokenModifiers: [String]
+	/// The formats the client supports.
 	public var formats: [TokenFormat]
+	/// Whether the client supports tokens that can overlap each other.
 	public var overlappingTokenSupport: Bool?
+	/// Whether the client supports tokens that can span multiple lines.
 	public var multilineTokenSupport: Bool?
+	/// Whether the client supports a server actively cancelling a semantic token request.
 	public var serverCancelSupport: Bool?
+	/// Whether the client uses semantic tokens to augment syntax tokens.
 	public var augmentsSyntaxTokens: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		dynamicRegistration: Bool = false,
 		requests: SemanticTokensClientCapabilities.Requests = .init(range: true, delta: true),
@@ -72,16 +105,25 @@ public struct SemanticTokensClientCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// The legend used by the server to encode semantic tokens.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensLegend: Codable, Hashable, Sendable {
+	/// The token types the server uses.
 	public var tokenTypes: [String]
+	/// The token modifiers the server uses.
 	public var tokenModifiers: [String]
 
+	/// Creates an instance from its parts.
 	public init(tokenTypes: [String], tokenModifiers: [String]) {
 		self.tokenTypes = tokenTypes
 		self.tokenModifiers = tokenModifiers
 	}
 }
 
+/// Predefined semantic token types.
+///
+/// - Since: 3.16.0
 public enum SemanticTokenTypes: String, Codable, Hashable, CaseIterable, Sendable {
 	case namespace = "namespace"
 	case type = "type"
@@ -111,6 +153,9 @@ public enum SemanticTokenTypes: String, Codable, Hashable, CaseIterable, Sendabl
 	}
 }
 
+/// Predefined semantic token modifiers.
+///
+/// - Since: 3.16.0
 public enum SemanticTokenModifiers: String, Codable, Hashable, CaseIterable, Sendable {
 	case declaration = "declaration"
 	case definition = "definition"
@@ -128,31 +173,45 @@ public enum SemanticTokenModifiers: String, Codable, Hashable, CaseIterable, Sen
 	}
 }
 
+/// Parameters for the `textDocument/semanticTokens/full` request.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public var workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public var partialResultToken: ProgressToken?
+	/// The text document.
 	public var textDocument: TextDocumentIdentifier
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier) {
 		self.textDocument = textDocument
 	}
 }
 
-// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSelector
+/// A single semantic token with its position and type information.
 public struct SemanticToken: Codable, Hashable, Sendable {
 	// typealias EncodedTuple = (line: UInt32, char: UInt32, length: UInt32, type: UInt32, modifiers: UInt32)
 
+	/// The zero-based line number.
 	public let line: UInt32
+	/// The zero-based character offset.
 	public let char: UInt32
+	/// The length of the token.
 	public let length: UInt32
+	/// The token type index into the legend.
 	public let type: UInt32
+	/// Bit flags for token modifiers.
 	public let modifiers: UInt32
 
+	/// The number of fields per encoded token.
 	public static let numFields = 5
 
 	// public func toArray() -> EncodedTuple {
 	// }
 
+	/// Creates an instance from its parts.
 	public init(line: UInt32, char: UInt32, length: UInt32, type: UInt32, modifiers: UInt32 = 0) {
 		self.line = line
 		self.char = char
@@ -162,18 +221,19 @@ public struct SemanticToken: Codable, Hashable, Sendable {
 	}
 }
 
+/// Semantic tokens result.
+///
+/// - Since: 3.16.0
 public struct SemanticTokens: Codable, Hashable, Sendable {
-	/**
-	 * An optional result id. If provided and clients support delta updating
-	 * the client will include the result id in the next semantic token request.
-	 * A server can then instead of computing all semantic tokens again simply
-	 * send a delta.
-	 */
+	/// An optional result id. If provided and clients support delta updating,
+	/// the client will include the result id in the next semantic token request.
+	/// A server can then send a delta instead of recomputing all semantic tokens.
 	public var resultId: String?
 
 	/// Encoded token data
 	public var data: [UInt32]
 
+	/// Creates an instance from a result ID and raw encoded data.
 	public init(resultId: String? = nil, data: [UInt32]) {
 		self.resultId = resultId
 		self.data = data
@@ -279,43 +339,76 @@ public struct SemanticTokens: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/semanticTokens/full`.
 public typealias SemanticTokensResponse = SemanticTokens?
 
+/// A partial result for semantic tokens.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensPartialResult: Codable, Hashable, Sendable {
+	/// The encoded token data.
 	public var data: [UInt32]
 }
 
+/// Parameters for the `textDocument/semanticTokens/full/delta` request.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensDeltaParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public var workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public var partialResultToken: ProgressToken?
+	/// The text document.
 	public var textDocument: TextDocumentIdentifier
+	/// The result ID of a previous response to compute the delta from.
 	public var previousResultId: String
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier, previousResultId: String) {
 		self.textDocument = textDocument
 		self.previousResultId = previousResultId
 	}
 }
 
+/// Describes an edit to semantic tokens.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensEdit: Codable, Hashable, Sendable {
+	/// The start offset of the edit.
 	public var start: UInt
+	/// The number of elements to remove.
 	public var deleteCount: UInt
+	/// The elements to insert.
 	public var data: [UInt32]?
 }
 
+/// A delta result for semantic tokens.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensDelta: Codable, Hashable, Sendable {
+	/// An optional result ID for further delta requests.
 	public var resultId: String?
+	/// The semantic token edits.
 	public var edits: [SemanticTokensEdit]
 }
 
+/// The response type for `textDocument/semanticTokens/full/delta`.
 public typealias SemanticTokensDeltaResponse = TwoTypeOption<SemanticTokens, SemanticTokensDelta>?
 
+/// Parameters for the `textDocument/semanticTokens/range` request.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensRangeParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public var workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public var partialResultToken: ProgressToken?
+	/// The text document.
 	public var textDocument: TextDocumentIdentifier
+	/// The range the semantic tokens are requested for.
 	public var range: LSPRange
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier, range: LSPRange) {
 		self.textDocument = textDocument
 		self.range = range
@@ -323,6 +416,7 @@ public struct SemanticTokensRangeParams: Codable, Hashable, Sendable {
 }
 
 extension TwoTypeOption where T == SemanticTokens, U == SemanticTokensDelta {
+	/// The result id regardless of the response variant, if any.
 	public var resultId: String? {
 		switch self {
 		case .optionA(let token):

--- a/Sources/LanguageServerProtocol/LanguageFeatures/SignatureHelp.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/SignatureHelp.swift
@@ -1,19 +1,32 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/signatureHelp` request.
 public struct SignatureHelpClientCapabilities: Codable, Hashable, Sendable {
+	/// Client capabilities specific to signature information.
 	public struct SignatureInformation: Codable, Hashable, Sendable {
+		/// Client capabilities specific to parameter information.
 		public struct ParameterInformation: Codable, Hashable, Sendable {
+			/// Whether the client supports processing label offsets.
+			///
+			/// - Since: 3.14.0
 			public var labelOffsetSupport: Bool?
 
+			/// Creates an instance from its parts.
 			public init(labelOffsetSupport: Bool? = nil) {
 				self.labelOffsetSupport = labelOffsetSupport
 			}
 		}
 
+		/// The content formats for documentation the client supports.
 		public var documentationFormat: [MarkupKind]?
+		/// Client capabilities specific to parameter information.
 		public var parameterInformation: ParameterInformation?
+		/// Whether the client supports the `activeParameter` property.
+		///
+		/// - Since: 3.16.0
 		public var activeParameterSupport: Bool?
 
+		/// Creates an instance from its parts.
 		public init(
 			documentationFormat: [MarkupKind]? = nil,
 			parameterInformation: ParameterInformation? = nil, activeParameterSupport: Bool? = nil
@@ -23,6 +36,7 @@ public struct SignatureHelpClientCapabilities: Codable, Hashable, Sendable {
 			self.activeParameterSupport = activeParameterSupport
 		}
 
+		/// Creates an instance using a label offset support flag.
 		public init(
 			documentationFormat: [MarkupKind]? = nil, labelOffsetSupport: Bool? = nil,
 			activeParameterSupport: Bool? = nil
@@ -34,10 +48,16 @@ public struct SignatureHelpClientCapabilities: Codable, Hashable, Sendable {
 		}
 	}
 
+	/// Whether dynamic registration is supported.
 	public var dynamicRegistration: Bool?
+	/// Client capabilities specific to signature information.
 	public var signatureInformation: SignatureInformation?
+	/// Whether the client supports sending additional context information.
+	///
+	/// - Since: 3.15.0
 	public var contextSupport: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		dynamicRegistration: Bool?,
 		signatureInformation: SignatureHelpClientCapabilities.SignatureInformation?,
@@ -49,10 +69,14 @@ public struct SignatureHelpClientCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// Represents a parameter of a callable-signature.
 public struct ParameterInformation: Codable, Hashable, Sendable {
+	/// The label of this parameter information.
 	public var label: TwoTypeOption<String, [UInt]>
+	/// The human-readable doc-comment of this parameter.
 	public var documentation: TwoTypeOption<String, MarkupContent>?
 
+	/// Creates an instance from its parts.
 	public init(
 		label: TwoTypeOption<String, [UInt]>,
 		documentation: TwoTypeOption<String, MarkupContent>? = nil
@@ -62,12 +86,20 @@ public struct ParameterInformation: Codable, Hashable, Sendable {
 	}
 }
 
+/// Represents the signature of something callable.
 public struct SignatureInformation: Codable, Hashable, Sendable {
+	/// The label of this signature.
 	public var label: String
+	/// The human-readable doc-comment of this signature.
 	public var documentation: TwoTypeOption<String, MarkupContent>?
+	/// The parameters of this signature.
 	public var parameters: [ParameterInformation]?
+	/// The index of the active parameter.
+	///
+	/// - Since: 3.16.0
 	public var activeParameter: UInt?
 
+	/// Creates an instance from its parts.
 	public init(
 		label: String, documentation: TwoTypeOption<String, MarkupContent>? = nil,
 		parameters: [ParameterInformation]? = nil, activeParameter: UInt? = nil
@@ -79,11 +111,16 @@ public struct SignatureInformation: Codable, Hashable, Sendable {
 	}
 }
 
+/// Signature help represents the signature of something callable.
 public struct SignatureHelp: Codable, Hashable, Sendable {
+	/// One or more signatures.
 	public let signatures: [SignatureInformation]
+	/// The active signature.
 	public let activeSignature: Int?
+	/// The active parameter of the active signature.
 	public let activeParameter: Int?
 
+	/// Creates an instance from its parts.
 	public init(
 		signatures: [SignatureInformation], activeSignature: Int? = nil, activeParameter: Int? = nil
 	) {
@@ -93,10 +130,14 @@ public struct SignatureHelp: Codable, Hashable, Sendable {
 	}
 }
 
+/// Registration options for signature help.
 public struct SignatureHelpRegistrationOptions: Codable, Hashable, Sendable {
+	/// A document selector to identify the scope of the registration, if any.
 	public let documentSelector: DocumentSelector?
+	/// The characters that trigger signature help, if any.
 	public let triggerCharacters: [String]?
 
+	/// Creates an instance from its parts.
 	public init(
 		documentSelector: DocumentSelector? = nil,
 		triggerCharacters: [String]? = nil
@@ -106,4 +147,5 @@ public struct SignatureHelpRegistrationOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/signatureHelp`.
 public typealias SignatureHelpResponse = SignatureHelp?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/TypeDefinition.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/TypeDefinition.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Client capabilities for the `textDocument/typeDefinition` request.
 public typealias TypeDefinitionClientCapabilities = DynamicRegistrationLinkSupportClientCapabilities
 
+/// The response type for `textDocument/typeDefinition`.
 public typealias TypeDefinitionResponse = ThreeTypeOption<Location, [Location], [LocationLink]>?

--- a/Sources/LanguageServerProtocol/LanguageFeatures/TypeHeirarchy.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/TypeHeirarchy.swift
@@ -1,12 +1,22 @@
 import Foundation
 
+/// Server capabilities for the type hierarchy feature.
+///
+/// - Since: 3.17.0
 public typealias TypeHierarchyOptions = WorkDoneProgressOptions
 
+/// Registration options for type hierarchy.
+///
+/// - Since: 3.17.0
 public struct TypeHierarchyRegistrationOptions: Codable, Hashable, Sendable {
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public let position: Position
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
 
+	/// Creates an instance from its parts.
 	public init(
 		textDocument: TextDocumentIdentifier,
 		position: Position,
@@ -18,11 +28,18 @@ public struct TypeHierarchyRegistrationOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/prepareTypeHierarchy` request.
+///
+/// - Since: 3.17.0
 public struct TypeHierarchyPrepareParams: Codable, Hashable, Sendable {
+	/// The text document.
 	public let textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public let position: Position
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
 
+	/// Creates an instance from its parts.
 	public init(
 		textDocument: TextDocumentIdentifier,
 		position: Position,
@@ -34,16 +51,28 @@ public struct TypeHierarchyPrepareParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// Represents programming constructs in the context of type hierarchy.
+///
+/// - Since: 3.17.0
 public struct TypeHierarchyItem: Codable, Hashable, Sendable {
+	/// The name of this item.
 	public let name: String
+	/// The kind of this item.
 	public let kind: SymbolKind
+	/// Tags for this item.
 	public let tags: [SymbolTag]?
+	/// More detail for this item, e.g. the signature of a function.
 	public let detail: String?
+	/// The resource identifier of this item.
 	public let uri: DocumentUri
+	/// The range enclosing this symbol.
 	public let range: LSPRange
+	/// The range that should be selected and revealed.
 	public let selectionRange: LSPRange
+	/// A data entry field preserved between request rounds.
 	public let data: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(
 		name: String,
 		kind: SymbolKind,
@@ -65,13 +94,21 @@ public struct TypeHierarchyItem: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `textDocument/prepareTypeHierarchy`.
 public typealias PrepareTypeHeirarchyResponse = [TypeHierarchyItem]?
 
+/// Parameters for the `typeHierarchy/subtypes` request.
+///
+/// - Since: 3.17.0
 public struct TypeHierarchySubtypesParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public let partialResultToken: ProgressToken?
+	/// The type hierarchy item to resolve subtypes for.
 	public let item: TypeHierarchyItem
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil,
 		item: TypeHierarchyItem
@@ -82,13 +119,21 @@ public struct TypeHierarchySubtypesParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `typeHierarchy/subtypes`.
 public typealias TypeHierarchySubtypesResponse = [TypeHierarchyItem]?
 
+/// Parameters for the `typeHierarchy/supertypes` request.
+///
+/// - Since: 3.17.0
 public struct TypeHierarchySupertypesParams: Codable, Hashable, Sendable {
+	/// An optional token for work done progress.
 	public let workDoneToken: ProgressToken?
+	/// An optional token for partial results.
 	public let partialResultToken: ProgressToken?
+	/// The type hierarchy item to resolve supertypes for.
 	public let item: TypeHierarchyItem
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil,
 		item: TypeHierarchyItem
@@ -99,4 +144,5 @@ public struct TypeHierarchySupertypesParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `typeHierarchy/supertypes`.
 public typealias TypeHierarchySupertypesResponse = [TypeHierarchyItem]?

--- a/Sources/LanguageServerProtocol/LanguageServerProtocol.swift
+++ b/Sources/LanguageServerProtocol/LanguageServerProtocol.swift
@@ -1,35 +1,56 @@
 import JSONRPC
 
+/// A placeholder type for responses that are not used.
 public typealias UnusedResult = LSPAny?
+/// A placeholder type for request parameters that are not used.
 public typealias UnusedParam = LSPAny?
 
+/// An error that occurs during LSP message dispatch.
 public enum ProtocolError: Error {
+	/// The method string was not recognized.
 	case unrecognizedMethod(String)
+	/// Required parameters were missing from the message.
 	case missingParams
+	/// A dynamic registration method was not handled.
 	case unhandledRegistrationMethod(String)
+	/// No reply was available for a request.
 	case missingReply
 }
 
+/// An event received by a server from a client.
 public enum ClientEvent: Sendable {
+	/// The result type for request handlers.
 	public typealias RequestResult = Result<Encodable & Sendable, AnyJSONRPCResponseError>
+	/// A closure that handles a request result.
 	public typealias RequestHandler = @Sendable (RequestResult) async -> Void
 
+	/// A request with its JSON-RPC id.
 	case request(id: JSONId, request: ClientRequest)
+	/// A notification.
 	case notification(ClientNotification)
+	/// A protocol-level error.
 	case error(Error)
 }
 
+/// An event received by a client from a server.
 public enum ServerEvent: Sendable {
+	/// The result type for request handlers.
 	public typealias RequestResult = Result<Encodable & Sendable, AnyJSONRPCResponseError>
+	/// A closure that handles a request result.
 	public typealias RequestHandler = @Sendable (RequestResult) async -> Void
 
+	/// A request with its JSON-RPC id.
 	case request(id: JSONId, request: ServerRequest)
+	/// A notification.
 	case notification(ServerNotification)
+	/// A protocol-level error.
 	case error(Error)
 	// case error(ServerError)
 }
 
+/// A notification sent from the client to the server.
 public enum ClientNotification: Sendable, Hashable {
+	/// The LSP method string for each client notification.
 	public enum Method: String, Hashable, Sendable {
 		case initialized
 		case exit
@@ -66,6 +87,7 @@ public enum ClientNotification: Sendable, Hashable {
 	case workspaceDidRenameFiles(RenameFilesParams)
 	case workspaceDidDeleteFiles(DeleteFilesParams)
 
+	/// The method string corresponding to this notification.
 	public var method: Method {
 		switch self {
 		case .initialized:
@@ -104,18 +126,23 @@ public enum ClientNotification: Sendable, Hashable {
 	}
 }
 
+/// A request sent from the client to the server.
 public enum ClientRequest: Sendable {
+	/// A closure that handles a typed response.
 	public typealias Handler<T: Sendable & Encodable> = @Sendable (
 		Result<T, AnyJSONRPCResponseError>
 	) async -> Void
+	/// A closure that handles an error-only response.
 	public typealias ErrorOnlyHandler = @Sendable (AnyJSONRPCResponseError?) async -> Void
 
 	// NOTE: The same `ClientRequest` type is used on the client side and the server side, only the server use the handler to send back the response, on the client side we use the `NullHandler`, which will never be called
+	/// A no-op handler used on the client side where no response callback is needed.
 	@Sendable
 	public static func NullHandler<T>(result: Result<T, AnyJSONRPCResponseError>) async {
 		// throw NullHandlerError.notImplemented(result)
 	}
 
+	/// The LSP method string for each client request.
 	public enum Method: String, Hashable, Sendable {
 		case initialize
 		case shutdown
@@ -226,6 +253,7 @@ public enum ClientRequest: Sendable {
 		TypeHierarchySupertypesParams, Handler<TypeHierarchySupertypesResponse>)
 	case custom(String, LSPAny, Handler<LSPAny>)
 
+	/// The method string corresponding to this request.
 	public var method: Method {
 		switch self {
 		case .initialize:
@@ -335,10 +363,11 @@ public enum ClientRequest: Sendable {
 }
 
 extension ClientRequest: Equatable {
-	/// Check for equality
-	///
-	/// This really stinks. But, the handler parameter was a big win for server-side development, and this is a one-time cost. Still, error-prone. Please take care when adding/modifying.
+	/// Returns whether two requests are equal, comparing only their parameters and ignoring handlers.
 	public static func == (lhs: ClientRequest, rhs: ClientRequest) -> Bool {
+		// This really stinks. But, the handler parameter was a big win for server-side development, and
+		// this is a one-time cost. Still, error-prone. Please take care when adding/modifying.
+
 		switch (lhs, rhs) {
 		case let (
 			.callHierarchyIncomingCalls(lhsParam, _), .callHierarchyIncomingCalls(rhsParam, _)
@@ -450,7 +479,9 @@ extension ClientRequest: Equatable {
 	}
 }
 
+/// A notification sent from the server to the client.
 public enum ServerNotification: Sendable, Hashable {
+	/// The LSP method string for each server notification.
 	public enum Method: String, Hashable, Sendable {
 		case windowLogMessage = "window/logMessage"
 		case windowShowMessage = "window/showMessage"
@@ -469,6 +500,7 @@ public enum ServerNotification: Sendable, Hashable {
 	case protocolProgress(ProgressParams)
 	case protocolLogTrace(LogTraceParams)
 
+	/// The method string corresponding to this notification.
 	public var method: Method {
 		switch self {
 		case .windowLogMessage:
@@ -489,13 +521,18 @@ public enum ServerNotification: Sendable, Hashable {
 	}
 }
 
+/// A request sent from the server to the client.
 public enum ServerRequest: Sendable {
+	/// A closure that handles a typed response.
 	public typealias Handler<T: Sendable & Encodable> = @Sendable (
 		Result<T, AnyJSONRPCResponseError>
 	) async -> Void
+	/// A closure that handles a void response.
 	public typealias VoidHandler = @Sendable () async -> Void
+	/// A closure that handles an error-only response.
 	public typealias ErrorOnlyHandler = @Sendable (AnyJSONRPCResponseError?) async -> Void
 
+	/// The LSP method string for each server request.
 	public enum Method: String {
 		case workspaceConfiguration = "workspace/configuration"
 		case workspaceFolders = "workspace/workspaceFolders"
@@ -522,6 +559,7 @@ public enum ServerRequest: Sendable {
 	case windowWorkDoneProgressCreate(WorkDoneProgressCreateParams, ErrorOnlyHandler)
 	case custom(String, LSPAny, Handler<LSPAny>)
 
+	/// The method string corresponding to this request.
 	public var method: Method {
 		switch self {
 		case .workspaceConfiguration:
@@ -549,6 +587,7 @@ public enum ServerRequest: Sendable {
 		}
 	}
 
+	/// Responds to this request with a generic internal error.
 	public func relyWithError(_ error: Error) async {
 		let protocolError = AnyJSONRPCResponseError(
 			code: JSONRPCErrors.internalError, message: "unsupported", data: nil)
@@ -580,7 +619,9 @@ public enum ServerRequest: Sendable {
 	}
 }
 
+/// A dynamic registration sent by the server to the client.
 public enum ServerRegistration {
+	/// The LSP method string for each registerable capability.
 	public enum Method: String {
 		case workspaceDidChangeWatchedFiles = "workspace/didChangeWatchedFiles"
 		case workspaceDidChangeConfiguration = "workspace/didChangeConfiguration"
@@ -594,6 +635,7 @@ public enum ServerRegistration {
 	case workspaceDidChangeConfiguration
 	case workspaceDidChangeWorkspaceFolders
 
+	/// The method string corresponding to this registration.
 	public var method: Method {
 		switch self {
 		case .workspaceDidChangeWatchedFiles:

--- a/Sources/LanguageServerProtocol/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ServerCapabilities.swift
@@ -1,14 +1,21 @@
 import Foundation
 
+/// Combined options for text document registration with static registration, work done progress, and position.
 public struct StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions: Codable, Hashable,
 	Sendable
 {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// The text document.
 	public var textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public var position: Position
+	/// A document selector to identify the scope of the registration, if any.
 	public var documentSelector: DocumentSelector?
+	/// The id used to register the request, if any.
 	public var id: String?
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneProgress: Bool? = nil,
 		textDocument: TextDocumentIdentifier,
@@ -24,15 +31,22 @@ public struct StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions:
 	}
 }
 
+/// Combined options for text document registration with work done progress and partial result support.
 public struct PartialResultsWorkDoneProgressTextDocumentRegistrationOptions: Codable, Hashable,
 	Sendable
 {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// The text document.
 	public var textDocument: TextDocumentIdentifier
+	/// The position inside the text document.
 	public var position: Position
+	/// A document selector to identify the scope of the registration, if any.
 	public var documentSelector: DocumentSelector?
+	/// An optional token that a server can use to report partial results.
 	public var partialResultToken: ProgressToken?
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneProgress: Bool? = nil,
 		textDocument: TextDocumentIdentifier,
@@ -48,35 +62,52 @@ public struct PartialResultsWorkDoneProgressTextDocumentRegistrationOptions: Cod
 	}
 }
 
+/// Options to signal work done progress support on the server side.
 public struct WorkDoneProgressOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
 
+	/// Creates an instance from its parts.
 	public init(workDoneProgress: Bool? = nil) {
 		self.workDoneProgress = workDoneProgress
 	}
 }
 
+/// Options for save notifications.
 public struct SaveOptions: Codable, Hashable, Sendable {
+	/// Whether the client is supposed to include the content on save.
 	public let includeText: Bool?
 
+	/// Creates an instance from its parts.
 	public init(includeText: Bool? = nil) {
 		self.includeText = includeText
 	}
 }
 
+/// Defines how the host (editor) should sync document changes to the language server.
 public enum TextDocumentSyncKind: Int, Codable, Hashable, Sendable {
+	/// Documents should not be synced at all.
 	case none = 0
+	/// Documents are synced by always sending the full content.
 	case full = 1
+	/// Documents are synced by sending incremental updates.
 	case incremental = 2
 }
 
+/// Options for text document synchronization.
 public struct TextDocumentSyncOptions: Codable, Hashable, Sendable {
+	/// Whether open and close notifications are sent to the server.
 	public var openClose: Bool?
+	/// How documents are synced: none, full, or incremental.
 	public var change: TextDocumentSyncKind?
+	/// Whether `willSave` notifications are sent.
 	public var willSave: Bool?
+	/// Whether `willSaveWaitUntil` requests are supported.
 	public var willSaveWaitUntil: Bool?
+	/// Whether save notifications are sent, with optional configuration.
 	public var save: TwoTypeOption<Bool, SaveOptions>?
 
+	/// The resolved save options regardless of whether `save` was a bool or an options object.
 	public var effectiveSave: SaveOptions? {
 		switch save {
 		case nil:
@@ -88,6 +119,7 @@ public struct TextDocumentSyncOptions: Codable, Hashable, Sendable {
 		}
 	}
 
+	/// Creates an instance from its parts.
 	public init(
 		openClose: Bool? = nil, change: TextDocumentSyncKind? = nil, willSave: Bool? = nil,
 		willSaveWaitUntil: Bool? = nil, save: TwoTypeOption<Bool, SaveOptions>? = nil
@@ -101,21 +133,39 @@ public struct TextDocumentSyncOptions: Codable, Hashable, Sendable {
 
 }
 
+/// Server capabilities for completion requests.
 public struct CompletionOptions: Codable, Hashable, Sendable {
+	/// Server capabilities specific to `CompletionItem`.
+	///
+	/// - Since: 3.17.0
 	public struct CompletionItem: Codable, Hashable, Sendable {
+		/// Whether the server supports label details.
+		///
+		/// - Since: 3.17.0
 		public var labelDetailsSupport: Bool?
 
+		/// Creates an instance from its parts.
 		public init(labelDetailsSupport: Bool?) {
 			self.labelDetailsSupport = labelDetailsSupport
 		}
 	}
 
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// The characters that trigger completion automatically, if any.
 	public var triggerCharacters: [String]?
+	/// The default commit characters for all completion items, if any.
+	///
+	/// - Since: 3.2.0
 	public var allCommitCharacters: [String]?
+	/// Whether the server supports resolving additional completion item properties.
 	public var resolveProvider: Bool?
+	/// Server capabilities specific to completion items, if any.
+	///
+	/// - Since: 3.17.0
 	public var completionItem: CompletionItem?
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneProgress: Bool,
 		triggerCharacters: [String]?,
@@ -131,13 +181,21 @@ public struct CompletionOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Server capabilities for hover requests.
 public typealias HoverOptions = WorkDoneProgressOptions
 
+/// Server capabilities for signature help requests.
 public struct SignatureHelpOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// The characters that trigger signature help automatically, if any.
 	public var triggerCharacters: [String]?
+	/// The characters that re-trigger signature help when already active, if any.
+	///
+	/// - Since: 3.15.0
 	public var retriggerCharacters: [String]?
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneProgress: Bool? = nil,
 		triggerCharacters: [String]? = nil,
@@ -149,48 +207,72 @@ public struct SignatureHelpOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Server capabilities for declaration requests.
+///
+/// - Since: 3.14.0
 public typealias DeclarationOptions = WorkDoneProgressOptions
 
+/// Registration options for declaration requests.
+///
+/// - Since: 3.14.0
 public typealias DeclarationRegistrationOptions =
 	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
+/// Server capabilities for definition requests.
 public typealias DefinitionOptions = WorkDoneProgressOptions
 
+/// Server capabilities for type definition requests.
 public typealias TypeDefinitionOptions = WorkDoneProgressOptions
 
+/// Registration options for type definition requests.
 public typealias TypeDefinitionRegistrationOptions =
 	PartialResultsWorkDoneProgressTextDocumentRegistrationOptions
 
+/// Server capabilities for implementation requests.
 public typealias ImplementationOptions = WorkDoneProgressOptions
 
+/// Registration options for implementation requests.
 public typealias ImplementationRegistrationOptions =
 	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
+/// Server capabilities for find references requests.
 public typealias ReferenceOptions = WorkDoneProgressOptions
 
+/// Server capabilities for document symbol requests.
 public struct DocumentSymbolOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// A human-readable string shown when multiple outlines trees are shown for the same document.
 	public var label: String?
 
+	/// Creates an instance from its parts.
 	public init(workDoneProgress: Bool? = nil, label: String? = nil) {
 		self.workDoneProgress = workDoneProgress
 		self.label = label
 	}
 }
 
+/// Server capabilities for document color requests.
 public typealias DocumentColorOptions = WorkDoneProgressOptions
 
+/// Registration options for document color requests.
 public typealias DocumentColorRegistrationOptions =
 	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
+/// Server capabilities for document formatting requests.
 public typealias DocumentFormattingOptions = WorkDoneProgressOptions
 
+/// Server capabilities for document range formatting requests.
 public typealias DocumentRangeFormattingOptions = WorkDoneProgressOptions
 
+/// Server capabilities for on-type formatting.
 public struct DocumentOnTypeFormattingOptions: Codable, Hashable, Sendable {
+	/// A character on which formatting should be triggered.
 	public var firstTriggerCharacter: String
+	/// More trigger characters, if any.
 	public var moreTriggerCharacter: [String]?
 
+	/// Creates an instance from its parts.
 	public init(
 		firstTriggerCharacter: String,
 		moreTriggerCharacter: [String]? = nil
@@ -200,22 +282,38 @@ public struct DocumentOnTypeFormattingOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Server capabilities for folding range requests.
 public typealias FoldingRangeOptions = WorkDoneProgressOptions
 
+/// Registration options for folding range requests.
 public typealias FoldingRangeRegistrationOptions =
 	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
+/// Server capabilities for linked editing range requests.
+///
+/// - Since: 3.16.0
 public typealias LinkedEditingRangeOptions = WorkDoneProgressOptions
 
+/// Registration options for linked editing range requests.
+///
+/// - Since: 3.16.0
 public typealias LinkedEditingRangeRegistrationOptions =
 	StaticRegistrationWorkDoneProgressTextDocumentRegistrationOptions
 
+/// Server capabilities for semantic tokens.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// The legend describing token types and modifiers.
 	public var legend: SemanticTokensLegend
+	/// Whether the server supports range requests.
 	public var range: SemanticTokensClientCapabilities.Requests.RangeOption?
+	/// Whether the server supports full document requests.
 	public var full: SemanticTokensClientCapabilities.Requests.FullOption?
 
+	/// Creates an instance from its parts.
 	public init(
 		workDoneProgress: Bool? = nil, legend: SemanticTokensLegend,
 		range: SemanticTokensClientCapabilities.Requests.RangeOption? = nil,
@@ -228,14 +326,24 @@ public struct SemanticTokensOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Registration options for semantic tokens.
+///
+/// - Since: 3.16.0
 public struct SemanticTokensRegistrationOptions: Codable, Hashable, Sendable {
+	/// A document selector to identify the scope of the registration, if any.
 	public var documentSelector: DocumentSelector?
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// The legend describing token types and modifiers.
 	public var legend: SemanticTokensLegend
+	/// Whether the server supports range requests.
 	public var range: SemanticTokensClientCapabilities.Requests.RangeOption?
+	/// Whether the server supports full document requests.
 	public var full: SemanticTokensClientCapabilities.Requests.FullOption?
+	/// The id used to register the request, if any.
 	public var id: String?
 
+	/// Creates an instance from its parts.
 	public init(
 		documentSelector: DocumentSelector? = nil, workDoneProgress: Bool? = nil,
 		legend: SemanticTokensLegend,
@@ -251,15 +359,25 @@ public struct SemanticTokensRegistrationOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Server capabilities for moniker requests.
+///
+/// - Since: 3.16.0
 public typealias MonikerOptions = WorkDoneProgressOptions
 
+/// Registration options for moniker requests.
+///
+/// - Since: 3.16.0
 public typealias MonikerRegistrationOptions =
 	PartialResultsWorkDoneProgressTextDocumentRegistrationOptions
 
+/// Server capabilities for workspace folders.
 public struct WorkspaceFoldersServerCapabilities: Codable, Hashable, Sendable {
+	/// Whether the server supports workspace folders.
 	public var supported: Bool?
+	/// Whether the server wants to receive workspace folder change notifications.
 	public var changeNotifications: TwoTypeOption<String, Bool>?
 
+	/// Creates an instance from its parts.
 	public init(
 		supported: Bool? = nil,
 		changeNotifications: TwoTypeOption<String, Bool>? = nil
@@ -269,16 +387,28 @@ public struct WorkspaceFoldersServerCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// The capabilities the language server provides.
 public struct ServerCapabilities: Codable, Hashable, Sendable {
+	/// Workspace specific server capabilities.
 	public struct Workspace: Codable, Hashable, Sendable {
+		/// Server capabilities for file operations.
+		///
+		/// - Since: 3.16.0
 		public struct FileOperations: Codable, Hashable, Sendable {
+			/// The server is interested in receiving `didCreateFiles` notifications.
 			public var didCreate: FileOperationRegistrationOptions?
+			/// The server is interested in receiving `willCreateFiles` requests.
 			public var willCreate: FileOperationRegistrationOptions?
+			/// The server is interested in receiving `didRenameFiles` notifications.
 			public var didRename: FileOperationRegistrationOptions?
+			/// The server is interested in receiving `willRenameFiles` requests.
 			public var willRename: FileOperationRegistrationOptions?
+			/// The server is interested in receiving `didDeleteFiles` notifications.
 			public var didDelete: FileOperationRegistrationOptions?
+			/// The server is interested in receiving `willDeleteFiles` requests.
 			public var willDelete: FileOperationRegistrationOptions?
 
+			/// Creates an instance from its parts.
 			public init(
 				didCreate: FileOperationRegistrationOptions? = nil,
 				willCreate: FileOperationRegistrationOptions? = nil,
@@ -296,9 +426,12 @@ public struct ServerCapabilities: Codable, Hashable, Sendable {
 			}
 		}
 
+		/// Workspace folder server capabilities, if any.
 		public var workspaceFolders: WorkspaceFoldersServerCapabilities?
+		/// File operation server capabilities, if any.
 		public var fileOperations: FileOperations?
 
+		/// Creates an instance from its parts.
 		public init(
 			workspaceFolders: WorkspaceFoldersServerCapabilities? = nil,
 			fileOperations: FileOperations? = nil
@@ -308,50 +441,83 @@ public struct ServerCapabilities: Codable, Hashable, Sendable {
 		}
 	}
 
+	/// How text documents are synced, if supported.
 	public var textDocumentSync: TwoTypeOption<TextDocumentSyncOptions, TextDocumentSyncKind>?
+	/// The server provides completion support, if any.
 	public var completionProvider: CompletionOptions?
+	/// The server provides hover support.
 	public var hoverProvider: TwoTypeOption<Bool, HoverOptions>?
+	/// The server provides signature help support, if any.
 	public var signatureHelpProvider: SignatureHelpOptions?
+	/// The server provides go to declaration support.
 	public var declarationProvider:
 		ThreeTypeOption<Bool, DeclarationOptions, DeclarationRegistrationOptions>?
+	/// The server provides go to definition support.
 	public var definitionProvider: TwoTypeOption<Bool, DefinitionOptions>?
+	/// The server provides go to type definition support.
 	public var typeDefinitionProvider:
 		ThreeTypeOption<Bool, TypeDefinitionOptions, TypeDefinitionRegistrationOptions>?
+	/// The server provides go to implementation support.
 	public var implementationProvider:
 		ThreeTypeOption<Bool, ImplementationOptions, ImplementationRegistrationOptions>?
+	/// The server provides find references support.
 	public var referencesProvider: TwoTypeOption<Bool, ReferenceOptions>?
+	/// The server provides document highlight support.
 	public var documentHighlightProvider: TwoTypeOption<Bool, DocumentHighlightOptions>?
+	/// The server provides document symbol support.
 	public var documentSymbolProvider: TwoTypeOption<Bool, DocumentSymbolOptions>?
+	/// The server provides code actions.
 	public var codeActionProvider: TwoTypeOption<Bool, CodeActionOptions>?
+	/// The server provides code lens, if any.
 	public var codeLensProvider: CodeLensOptions?
+	/// The server provides document link support, if any.
 	public var documentLinkProvider: DocumentLinkOptions?
+	/// The server provides color provider support.
 	public var colorProvider:
 		ThreeTypeOption<Bool, DocumentColorOptions, DocumentColorRegistrationOptions>?
+	/// The server provides document formatting.
 	public var documentFormattingProvider: TwoTypeOption<Bool, DocumentFormattingOptions>?
+	/// The server provides document range formatting.
 	public var documentRangeFormattingProvider: TwoTypeOption<Bool, DocumentRangeFormattingOptions>?
+	/// The server provides document on-type formatting, if any.
 	public var documentOnTypeFormattingProvider: DocumentOnTypeFormattingOptions?
+	/// The server provides rename support.
 	public var renameProvider: TwoTypeOption<Bool, RenameOptions>?
+	/// The server provides folding range support.
 	public var foldingRangeProvider:
 		ThreeTypeOption<Bool, FoldingRangeOptions, FoldingRangeRegistrationOptions>?
+	/// The server provides execute command support, if any.
 	public var executeCommandProvider: ExecuteCommandOptions?
+	/// The server provides selection range support.
 	public var selectionRangeProvider:
 		ThreeTypeOption<Bool, SelectionRangeOptions, SelectionRangeRegistrationOptions>?
+	/// The server provides linked editing range support.
 	public var linkedEditingRangeProvider:
 		ThreeTypeOption<Bool, LinkedEditingRangeOptions, LinkedEditingRangeRegistrationOptions>?
+	/// The server provides call hierarchy support.
 	public var callHierarchyProvider:
 		ThreeTypeOption<Bool, CallHierarchyOptions, CallHierarchyRegistrationOptions>?
+	/// The server provides semantic tokens support.
 	public var semanticTokensProvider:
 		TwoTypeOption<SemanticTokensOptions, SemanticTokensRegistrationOptions>?
+	/// The server provides moniker support.
 	public var monikerProvider: ThreeTypeOption<Bool, MonikerOptions, MonikerRegistrationOptions>?
+	/// The server provides type hierarchy support.
 	public var typeHierarchyProvider:
 		ThreeTypeOption<Bool, TypeHierarchyOptions, TypeHierarchyRegistrationOptions>?
+	/// The server provides inlay hint support.
 	public var inlayHintProvider:
 		ThreeTypeOption<Bool, InlayHintOptions, InlayHintRegistrationOptions>?
+	/// The server provides pull diagnostics support.
 	public var diagnosticProvider: TwoTypeOption<DiagnosticOptions, DiagnosticRegistrationOptions>?
+	/// The server provides workspace symbol support.
 	public var workspaceSymbolProvider: TwoTypeOption<Bool, WorkspaceSymbolOptions>?
+	/// Workspace specific server capabilities, if any.
 	public var workspace: Workspace?
+	/// Experimental server capabilities, if any.
 	public var experimental: LSPAny?
 
+	/// Creates an instance with no capabilities set.
 	public init() {
 	}
 }

--- a/Sources/LanguageServerProtocol/TextSynchronization.swift
+++ b/Sources/LanguageServerProtocol/TextSynchronization.swift
@@ -1,18 +1,26 @@
 import Foundation
 
+/// Parameters for the `textDocument/didOpen` notification.
 public struct DidOpenTextDocumentParams: Codable, Hashable, Sendable {
+	/// The document that was opened.
 	public let textDocument: TextDocumentItem
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentItem) {
 		self.textDocument = textDocument
 	}
 }
 
+/// An event describing a change to a text document.
 public struct TextDocumentContentChangeEvent: Codable, Hashable, Sendable {
+	/// The range of the document that changed, if incremental. `nil` for full sync.
 	public let range: LSPRange?
+	/// The length of the range that got replaced (deprecated, use `range` instead).
 	public let rangeLength: Int?
+	/// The new text for the provided range, or the full document content.
 	public let text: String
 
+	/// Creates an instance from its parts.
 	public init(range: LSPRange?, rangeLength: Int?, text: String) {
 		self.range = range
 		self.rangeLength = rangeLength
@@ -20,10 +28,14 @@ public struct TextDocumentContentChangeEvent: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/didChange` notification.
 public struct DidChangeTextDocumentParams: Codable, Hashable, Sendable {
+	/// The document that did change, including the version number.
 	public let textDocument: VersionedTextDocumentIdentifier
+	/// The actual content changes.
 	public let contentChanges: [TextDocumentContentChangeEvent]
 
+	/// Creates an instance from its parts.
 	public init(
 		textDocument: VersionedTextDocumentIdentifier,
 		contentChanges: [TextDocumentContentChangeEvent]
@@ -32,21 +44,27 @@ public struct DidChangeTextDocumentParams: Codable, Hashable, Sendable {
 		self.contentChanges = contentChanges
 	}
 
+	/// Creates an instance from a URI, version, and content changes.
 	public init(uri: DocumentUri, version: Int, contentChanges: [TextDocumentContentChangeEvent]) {
 		self.textDocument = VersionedTextDocumentIdentifier(uri: uri, version: version)
 		self.contentChanges = contentChanges
 	}
 
+	/// Creates an instance from a URI, version, and a single content change.
 	public init(uri: DocumentUri, version: Int, contentChange: TextDocumentContentChangeEvent) {
 		self.textDocument = VersionedTextDocumentIdentifier(uri: uri, version: version)
 		self.contentChanges = [contentChange]
 	}
 }
 
+/// Registration options for text document change notifications.
 public struct TextDocumentChangeRegistrationOptions: Codable, Hashable, Sendable {
+	/// A document selector to identify the scope of the registration.
 	public let documentSelector: DocumentSelector?
+	/// How documents are synced.
 	public let syncKind: TextDocumentSyncKind
 
+	/// Creates an instance from its parts.
 	public init(
 		documentSelector: DocumentSelector?,
 		syncKind: TextDocumentSyncKind
@@ -56,15 +74,20 @@ public struct TextDocumentChangeRegistrationOptions: Codable, Hashable, Sendable
 	}
 }
 
+/// Parameters for the `textDocument/didSave` notification.
 public struct DidSaveTextDocumentParams: Codable, Hashable, Sendable {
+	/// The document that was saved.
 	public let textDocument: TextDocumentIdentifier
+	/// The content when saved, if requested via `includeText`.
 	public let text: String?
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier, text: String? = nil) {
 		self.textDocument = textDocument
 		self.text = text
 	}
 
+	/// Creates an instance from a document URI.
 	public init(uri: DocumentUri, text: String? = nil) {
 		let docId = TextDocumentIdentifier(uri: uri)
 
@@ -73,10 +96,14 @@ public struct DidSaveTextDocumentParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// Registration options for text document save notifications.
 public struct TextDocumentSaveRegistrationOptions: Codable, Hashable, Sendable {
+	/// A document selector to identify the scope of the registration.
 	public let documentSelector: DocumentSelector?
+	/// Whether the client is supposed to include the content on save.
 	public let includeText: Bool?
 
+	/// Creates an instance from its parts.
 	public init(
 		documentSelector: DocumentSelector?,
 		includeText: Bool? = nil
@@ -86,13 +113,17 @@ public struct TextDocumentSaveRegistrationOptions: Codable, Hashable, Sendable {
 	}
 }
 
+/// Parameters for the `textDocument/didClose` notification.
 public struct DidCloseTextDocumentParams: Codable, Hashable, Sendable {
+	/// The document that was closed.
 	public let textDocument: TextDocumentIdentifier
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier) {
 		self.textDocument = textDocument
 	}
 
+	/// Creates an instance from a document URI.
 	public init(uri: DocumentUri) {
 		let docId = TextDocumentIdentifier(uri: uri)
 
@@ -100,32 +131,47 @@ public struct DidCloseTextDocumentParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// The reason why a text document is saved.
 public enum TextDocumentSaveReason: Int, Codable, Hashable, Sendable {
+	/// Manually triggered, e.g. by the user pressing save.
 	case manual = 1
+	/// Automatic after a delay.
 	case afterDelay = 2
+	/// When the editor lost focus.
 	case focusOut = 3
 }
 
+/// Parameters for the `textDocument/willSave` notification.
 public struct WillSaveTextDocumentParams: Codable, Hashable, Sendable {
+	/// The document that will be saved.
 	public let textDocument: TextDocumentIdentifier
+	/// The reason for the save.
 	public let reason: TextDocumentSaveReason
 
+	/// Creates an instance from its parts.
 	public init(textDocument: TextDocumentIdentifier, reason: TextDocumentSaveReason) {
 		self.textDocument = textDocument
 		self.reason = reason
 	}
 }
 
+/// The response type for `textDocument/willSaveWaitUntil`.
 public typealias WillSaveWaitUntilResponse = [TextEdit]?
 
 /// A special text edit to provide an insert and a replace operation.
 ///
 /// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#insertReplaceEdit
+///
+/// - Since: 3.16.0
 public struct InsertReplaceEdit: Codable, Hashable, Sendable {
+	/// The string to be inserted.
 	public let newText: String
+	/// The range if the insert is requested.
 	public let insert: LSPRange
+	/// The range if the replace is requested.
 	public let replace: LSPRange
 
+	/// Creates an instance from its parts.
 	public init(newText: String, insert: LSPRange, replace: LSPRange) {
 		self.newText = newText
 		self.insert = insert
@@ -133,19 +179,25 @@ public struct InsertReplaceEdit: Codable, Hashable, Sendable {
 	}
 }
 
+/// A textual edit applicable to a text document.
 public struct TextEdit: Codable, Hashable, Sendable {
+	/// The range of the text document to be manipulated.
 	public let range: LSPRange
+	/// The string to be inserted. For delete operations use an empty string.
 	public let newText: String
 
+	/// Creates an instance from its parts.
 	public init(range: LSPRange, newText: String) {
 		self.range = range
 		self.newText = newText
 	}
 
+	/// Whether this edit has no effect (empty range and empty text).
 	public var isNoOp: Bool {
 		return range.isEmpty && newText.isEmpty
 	}
 
+	/// Whether this edit is a pure insertion (empty range with non-empty text).
 	public var isInsert: Bool {
 		return range.isEmpty && (newText.isEmpty == false)
 	}

--- a/Sources/LanguageServerProtocol/ThreeTypeOption.swift
+++ b/Sources/LanguageServerProtocol/ThreeTypeOption.swift
@@ -1,8 +1,12 @@
 import Foundation
 
+/// A union type that can hold one of three possible types.
 public enum ThreeTypeOption<T, U, V> {
+	/// The first variant.
 	case optionA(T)
+	/// The second variant.
 	case optionB(U)
+	/// The third variant.
 	case optionC(V)
 }
 

--- a/Sources/LanguageServerProtocol/TwoTypeOption.swift
+++ b/Sources/LanguageServerProtocol/TwoTypeOption.swift
@@ -1,7 +1,10 @@
 import Foundation
 
+/// A union type that can hold one of two possible types.
 public enum TwoTypeOption<T, U> {
+	/// The first variant.
 	case optionA(T)
+	/// The second variant.
 	case optionB(U)
 }
 

--- a/Sources/LanguageServerProtocol/Utility.swift
+++ b/Sources/LanguageServerProtocol/Utility.swift
@@ -1,8 +1,11 @@
 import Foundation
 
+/// A generic capability that only indicates whether dynamic registration is supported.
 public struct GenericDynamicRegistration: Codable, Hashable, Sendable {
+	/// Whether dynamic registration is supported.
 	public let dynamicRegistration: Bool?
 
+	/// Creates an instance from its parts.
 	public init(dynamicRegistration: Bool) {
 		self.dynamicRegistration = dynamicRegistration
 	}

--- a/Sources/LanguageServerProtocol/Window.swift
+++ b/Sources/LanguageServerProtocol/Window.swift
@@ -1,9 +1,14 @@
 import Foundation
 
+/// The message type used in `window/showMessage` and `window/logMessage`.
 public enum MessageType: Int, Codable, Hashable, Sendable {
+	/// An error message.
 	case error = 1
+	/// A warning message.
 	case warning = 2
+	/// An information message.
 	case info = 3
+	/// A log message.
 	case log = 4
 }
 
@@ -22,10 +27,14 @@ extension MessageType: CustomStringConvertible {
 	}
 }
 
+/// Parameters for the `window/logMessage` notification.
 public struct LogMessageParams: Codable, Hashable, Sendable {
+	/// The message type.
 	public let type: MessageType
+	/// The actual message.
 	public let message: String
 
+	/// Creates an instance from its parts.
 	public init(type: MessageType, message: String) {
 		self.type = type
 		self.message = message
@@ -38,14 +47,21 @@ extension LogMessageParams: CustomStringConvertible {
 	}
 }
 
+/// Parameters for the `window/showMessage` notification.
 public typealias ShowMessageParams = LogMessageParams
 
+/// Parameters for the `window/showDocument` request.
 public struct ShowDocumentParams: Hashable, Codable, Sendable {
+	/// The URI to show.
 	public var uri: URI
+	/// Whether to show the resource in an external program.
 	public var external: Bool?
+	/// Whether the editor should take focus.
 	public var takeFocus: Bool?
+	/// An optional selection range within the document.
 	public var selection: LSPRange?
 
+	/// Creates an instance from its parts.
 	public init(uri: URI, external: Bool? = nil, takeFocus: Bool? = nil, selection: LSPRange? = nil)
 	{
 		self.uri = uri
@@ -55,19 +71,26 @@ public struct ShowDocumentParams: Hashable, Codable, Sendable {
 	}
 }
 
+/// Parameters for the `window/workDoneProgress/create` request.
 public struct WorkDoneProgressCreateParams: Hashable, Codable, Sendable {
+	/// The token to be used to report progress.
 	public var token: ProgressToken
 
+	/// Creates an instance from its parts.
 	public init(token: ProgressToken) {
 		self.token = token
 	}
 }
 
+/// Parameters for the `window/workDoneProgress/cancel` notification.
 public typealias WorkDoneProgressCancelParams = WorkDoneProgressCreateParams
 
+/// The result of a `window/showDocument` request.
 public struct ShowDocumentResult: Hashable, Codable, Sendable {
+	/// Whether the show was successful.
 	public let success: Bool
 
+	/// Creates an instance from its parts.
 	public init(success: Bool) {
 		self.success = success
 	}

--- a/Sources/LanguageServerProtocol/Window/ShowMessageRequest.swift
+++ b/Sources/LanguageServerProtocol/Window/ShowMessageRequest.swift
@@ -1,18 +1,26 @@
 import Foundation
 
+/// An action item presented in a `window/showMessageRequest`.
 public struct MessageActionItem: Codable, Hashable, Sendable {
+	/// A short title shown in the UI for this action.
 	public var title: String
 
+	/// Creates an instance from its parts.
 	public init(title: String) {
 		self.title = title
 	}
 }
 
+/// Parameters for the `window/showMessageRequest` request.
 public struct ShowMessageRequestParams: Codable, Hashable, Sendable {
+	/// The message type.
 	public var type: MessageType
+	/// The actual message.
 	public var message: String
+	/// The message action items to present, if any.
 	public var actions: [MessageActionItem]?
 
+	/// Creates an instance from its parts.
 	public init(type: MessageType, message: String, actions: [MessageActionItem]? = nil) {
 		self.type = type
 		self.message = message
@@ -26,4 +34,5 @@ extension ShowMessageRequestParams: CustomStringConvertible {
 	}
 }
 
+/// The response type for `window/showMessageRequest`.
 public typealias ShowMessageRequestResponse = MessageActionItem?

--- a/Sources/LanguageServerProtocol/Workspace.swift
+++ b/Sources/LanguageServerProtocol/Workspace.swift
@@ -1,109 +1,162 @@
 import Foundation
 
+/// The kind of events to watch for file system changes.
 public struct WatchKind: OptionSet, Codable, Hashable, Sendable {
+	/// The raw option set value.
 	public let rawValue: Int
 
+	/// Creates a watch kind from a raw value.
 	public init(rawValue: Int) {
 		self.rawValue = rawValue
 	}
 
+	/// Interested in create events.
 	public static let create = WatchKind(rawValue: 1)
+	/// Interested in change events.
 	public static let change = WatchKind(rawValue: 2)
+	/// Interested in delete events.
 	public static let delete = WatchKind(rawValue: 4)
 
+	/// Interested in all event types.
 	public static let all: WatchKind = [.create, .change, .delete]
 }
 
+/// A file system watcher that is registered for file change events.
 public struct FileSystemWatcher: Codable, Hashable, Sendable {
+	/// The glob pattern to watch.
 	public var globPattern: String
+	/// The kind of events to watch for, if specified.
 	public var kind: WatchKind?
 
+	/// Creates an instance from its parts.
 	public init(globPattern: String, kind: WatchKind? = nil) {
 		self.globPattern = globPattern
 		self.kind = kind
 	}
 }
 
+/// Registration options for `workspace/didChangeWatchedFiles`.
 public struct DidChangeWatchedFilesRegistrationOptions: Codable, Hashable, Sendable {
+	/// The watchers to register.
 	public var watchers: [FileSystemWatcher]
 
+	/// Creates an instance from its parts.
 	public init(watchers: [FileSystemWatcher]) {
 		self.watchers = watchers
 	}
 }
 
+/// The file event type.
 public enum FileChangeType: Int, Codable, Hashable, Sendable {
+	/// The file got created.
 	case created = 1
+	/// The file got changed.
 	case changed = 2
+	/// The file got deleted.
 	case deleted = 3
 }
 
+/// An event describing a file change.
 public struct FileEvent: Codable, Hashable, Sendable {
+	/// The file's URI.
 	public var uri: DocumentUri
+	/// The change type.
 	public var type: FileChangeType
 
+	/// Creates an instance from its parts.
 	public init(uri: DocumentUri, type: FileChangeType) {
 		self.uri = uri
 		self.type = type
 	}
 }
 
+/// Parameters for the `workspace/didChangeWatchedFiles` notification.
 public struct DidChangeWatchedFilesParams: Codable, Hashable, Sendable {
+	/// The actual file events.
 	public var changes: [FileEvent]
 
+	/// Creates an instance from its parts.
 	public init(changes: [FileEvent]) {
 		self.changes = changes
 	}
 }
 
+/// A workspace folder.
 public struct WorkspaceFolder: Codable, Hashable, Sendable {
+	/// The associated URI for this workspace folder.
 	public let uri: String
+	/// The name of the workspace folder.
 	public let name: String
 
+	/// Creates an instance from its parts.
 	public init(uri: String, name: String) {
 		self.uri = uri
 		self.name = name
 	}
 }
 
+/// The workspace folder change event.
 public struct WorkspaceFoldersChangeEvent: Codable, Hashable, Sendable {
+	/// The array of added workspace folders.
 	public var added: [WorkspaceFolder]
+	/// The array of removed workspace folders.
 	public var removed: [WorkspaceFolder]
 
+	/// Creates an instance from its parts.
 	public init(added: [WorkspaceFolder], removed: [WorkspaceFolder]) {
 		self.added = added
 		self.removed = removed
 	}
 }
 
+/// Parameters for the `workspace/didChangeWorkspaceFolders` notification.
 public struct DidChangeWorkspaceFoldersParams: Codable, Hashable, Sendable {
+	/// The actual workspace folder change event.
 	public var event: WorkspaceFoldersChangeEvent
 
+	/// Creates an instance from its parts.
 	public init(event: WorkspaceFoldersChangeEvent) {
 		self.event = event
 	}
 }
 
+/// Parameters for the `workspace/didChangeConfiguration` notification.
 public struct DidChangeConfigurationParams: Codable, Hashable, Sendable {
+	/// The actual changed settings.
 	public var settings: LSPAny?
 
+	/// Creates an instance from its parts.
 	public init(settings: LSPAny) {
 		self.settings = settings
 	}
 }
 
+/// Tags for symbols.
+///
+/// - Since: 3.16.0
 public enum SymbolTag: Int, Codable, Hashable, CaseIterable, Sendable {
+	/// The symbol is deprecated.
 	case Deprecated = 1
 }
 
+/// Represents information about programming constructs like variables or functions.
 public struct SymbolInformation: Codable, Hashable, Sendable {
+	/// The name of this symbol.
 	public let name: String
+	/// The kind of this symbol.
 	public let kind: SymbolKind
+	/// Tags for this symbol.
+	///
+	/// - Since: 3.16.0
 	public let tags: [SymbolTag]?
+	/// Whether the symbol is deprecated.
 	public let deprecated: Bool?
+	/// The location of this symbol.
 	public let location: Location
+	/// The name of the symbol containing this symbol, if any.
 	public let containerName: String?
 
+	/// Creates an instance from its parts.
 	public init(
 		name: String, kind: SymbolKind, tags: [SymbolTag]? = nil, deprecated: Bool? = nil,
 		location: Location, containerName: String? = nil
@@ -117,16 +170,24 @@ public struct SymbolInformation: Codable, Hashable, Sendable {
 	}
 }
 
+/// Options to create a file.
 public struct CreateFileOptions: Codable, Hashable, Sendable {
+	/// Overwrite existing file. Takes precedence over `ignoreIfExists`.
 	public let overwrite: Bool?
+	/// Ignore if the file already exists.
 	public let ignoreIfExists: Bool?
 }
 
+/// Create file operation.
 public struct CreateFile: Codable, Hashable, Sendable {
+	/// The resource operation kind (always `"create"`).
 	public let kind: String
+	/// The resource to create.
 	public let uri: DocumentUri
+	/// Additional options, if any.
 	public let options: CreateFileOptions?
 
+	/// Creates an instance from its parts.
 	public init(kind: String, uri: DocumentUri, options: CreateFileOptions?) {
 		self.kind = kind
 		self.uri = uri
@@ -134,14 +195,21 @@ public struct CreateFile: Codable, Hashable, Sendable {
 	}
 }
 
+/// Options to rename a file.
 public typealias RenameFileOptions = CreateFileOptions
 
+/// Rename file operation.
 public struct RenameFile: Codable, Hashable, Sendable {
+	/// The resource operation kind (always `"rename"`).
 	public let kind: String
+	/// The old (existing) location.
 	public let oldUri: DocumentUri
+	/// The new location.
 	public let newUri: DocumentUri
+	/// Rename options.
 	public let options: RenameFileOptions
 
+	/// Creates an instance from its parts.
 	public init(kind: String, oldUri: DocumentUri, newUri: DocumentUri, options: RenameFileOptions)
 	{
 		self.kind = kind
@@ -151,21 +219,30 @@ public struct RenameFile: Codable, Hashable, Sendable {
 	}
 }
 
+/// Options to delete a file.
 public struct DeleteFileOptions: Codable, Hashable, Sendable {
+	/// Delete the content recursively if a folder is denoted.
 	public let recursive: Bool?
+	/// Ignore the operation if the file doesn't exist.
 	public let ignoreIfNotExists: Bool?
 
+	/// Creates an instance from its parts.
 	public init(recursive: Bool?, ignoreIfNotExists: Bool?) {
 		self.recursive = recursive
 		self.ignoreIfNotExists = ignoreIfNotExists
 	}
 }
 
+/// Delete file operation.
 public struct DeleteFile: Codable, Hashable, Sendable {
+	/// The resource operation kind (always `"delete"`).
 	public let kind: String
+	/// The file to delete.
 	public let uri: DocumentUri
+	/// Delete options.
 	public let options: DeleteFileOptions
 
+	/// Creates an instance from its parts.
 	public init(kind: String, uri: DocumentUri, options: DeleteFileOptions) {
 		self.kind = kind
 		self.uri = uri
@@ -173,20 +250,29 @@ public struct DeleteFile: Codable, Hashable, Sendable {
 	}
 }
 
+/// Describes textual changes on a single text document.
 public struct TextDocumentEdit: Codable, Hashable, Sendable {
+	/// The text document to change.
 	public let textDocument: VersionedTextDocumentIdentifier
+	/// The edits to be applied.
 	public let edits: [TextEdit]
 
+	/// Creates an instance from its parts.
 	public init(textDocument: VersionedTextDocumentIdentifier, edits: [TextEdit]) {
 		self.textDocument = textDocument
 		self.edits = edits
 	}
 }
 
+/// A document change in a workspace edit, which is either a text edit or a resource operation.
 public enum WorkspaceEditDocumentChange: Codable, Hashable, Sendable {
+	/// A text document edit.
 	case textDocumentEdit(TextDocumentEdit)
+	/// A create file operation.
 	case createFile(CreateFile)
+	/// A rename file operation.
 	case renameFile(RenameFile)
+	/// A delete file operation.
 	case deleteFile(DeleteFile)
 
 	public init(from decoder: Decoder) throws {
@@ -220,10 +306,14 @@ public enum WorkspaceEditDocumentChange: Codable, Hashable, Sendable {
 	}
 }
 
+/// A workspace edit represents changes to many resources managed in the workspace.
 public struct WorkspaceEdit: Codable, Hashable, Sendable {
+	/// Holds changes to existing resources, keyed by document URI.
 	public let changes: [DocumentUri: [TextEdit]]?
+	/// An array of `TextDocumentEdit`s or resource operations, depending on client capability.
 	public let documentChanges: [WorkspaceEditDocumentChange]?
 
+	/// Creates an instance from its parts.
 	public init(
 		changes: [DocumentUri: [TextEdit]]?, documentChanges: [WorkspaceEditDocumentChange]?
 	) {

--- a/Sources/LanguageServerProtocol/Workspace/ApplyEdit.swift
+++ b/Sources/LanguageServerProtocol/Workspace/ApplyEdit.swift
@@ -1,20 +1,29 @@
 import Foundation
 
+/// Parameters for the `workspace/applyEdit` request.
 public struct ApplyWorkspaceEditParams: Codable, Hashable, Sendable {
+	/// An optional label of the workspace edit.
 	public var label: String?
+	/// The edits to apply.
 	public var edit: WorkspaceEdit
 
+	/// Creates an instance from its parts.
 	public init(label: String? = nil, edit: WorkspaceEdit) {
 		self.label = label
 		self.edit = edit
 	}
 }
 
+/// The result returned from the `workspace/applyEdit` request.
 public struct ApplyWorkspaceEditResult: Codable, Hashable, Sendable {
+	/// Whether the edit was applied.
 	public var applied: Bool
+	/// A human-readable reason why the edit was not applied, if applicable.
 	public var failureReason: String?
+	/// The index of the change that failed, depending on the client capability.
 	public var failedChange: UInt?
 
+	/// Creates an instance from its parts.
 	public init(applied: Bool, failureReason: String? = nil, failedChange: UInt? = nil) {
 		self.applied = applied
 		self.failureReason = failureReason

--- a/Sources/LanguageServerProtocol/Workspace/Configuration.swift
+++ b/Sources/LanguageServerProtocol/Workspace/Configuration.swift
@@ -1,18 +1,25 @@
 import Foundation
 
+/// A configuration item to request from the client.
 public struct ConfigurationItem: Codable, Hashable, Sendable {
+	/// The scope to get the configuration section for.
 	public var scopeUri: DocumentUri?
+	/// The configuration section asked for.
 	public var section: String?
 
+	/// Creates an instance from its parts.
 	public init(scopeUri: DocumentUri?, section: String?) {
 		self.scopeUri = scopeUri
 		self.section = section
 	}
 }
 
+/// Parameters for the `workspace/configuration` request.
 public struct ConfigurationParams: Codable, Hashable, Sendable {
+	/// The configuration items to ask for.
 	public var items: [ConfigurationItem]
 
+	/// Creates an instance from its parts.
 	public init(items: [ConfigurationItem]) {
 		self.items = items
 	}

--- a/Sources/LanguageServerProtocol/Workspace/ExecuteCommand.swift
+++ b/Sources/LanguageServerProtocol/Workspace/ExecuteCommand.swift
@@ -1,24 +1,35 @@
 import Foundation
 
+/// Client capabilities for `workspace/executeCommand`.
 public typealias ExecuteCommandClientCapabilities = DynamicRegistrationClientCapabilities
 
+/// Server capabilities for the `workspace/executeCommand` request.
 public struct ExecuteCommandOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// The commands to be executed on the server.
 	public var commands: [String]
 
+	/// Creates an instance from its parts.
 	public init(workDoneProgress: Bool? = nil, commands: [String]) {
 		self.workDoneProgress = workDoneProgress
 		self.commands = commands
 	}
 }
 
+/// Registration options for execute command.
 public typealias ExecuteCommandRegistrationOptions = ExecuteCommandOptions
 
+/// Parameters for the `workspace/executeCommand` request.
 public struct ExecuteCommandParams: Codable, Hashable, Sendable {
+	/// An optional work done progress token.
 	public var workDoneToken: ProgressToken?
+	/// The identifier of the actual command handler.
 	public var command: String
+	/// Arguments the command should be invoked with.
 	public var arguments: [LSPAny]?
 
+	/// Creates an instance from its parts.
 	public init(workDoneToken: ProgressToken? = nil, command: String, arguments: [LSPAny]? = nil) {
 		self.workDoneToken = workDoneToken
 		self.command = command
@@ -26,4 +37,5 @@ public struct ExecuteCommandParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `workspace/executeCommand`.
 public typealias ExecuteCommandResponse = LSPAny

--- a/Sources/LanguageServerProtocol/Workspace/Folders.swift
+++ b/Sources/LanguageServerProtocol/Workspace/Folders.swift
@@ -1,1 +1,2 @@
+/// The response type for `workspace/workspaceFolders`.
 public typealias WorkspaceFoldersResponse = [WorkspaceFolder]?

--- a/Sources/LanguageServerProtocol/Workspace/Symbol.swift
+++ b/Sources/LanguageServerProtocol/Workspace/Symbol.swift
@@ -1,15 +1,27 @@
 import Foundation
 
+/// Client capabilities for the `workspace/symbol` request.
 public struct WorkspaceSymbolClientCapabilities: Codable, Hashable, Sendable {
+	/// The properties that a client can resolve lazily.
 	public struct Properties: Codable, Hashable, Sendable {
+		/// The properties that a client can resolve lazily.
 		public var properties: [String]
 	}
 
+	/// Whether the client supports dynamic registration.
 	public var dynamicRegistration: Bool?
+	/// The symbol kind values the client supports.
 	public var symbolKind: ValueSet<SymbolKind>?
+	/// The tag values the client supports.
+	///
+	/// - Since: 3.16.0
 	public var tagSupport: ValueSet<SymbolTag>?
+	/// The client supports partial result for resolve.
+	///
+	/// - Since: 3.17.0
 	public var resolveSupport: Properties?
 
+	/// Creates an instance from its parts.
 	public init(
 		dynamicRegistration: Bool?, symbolKind: [SymbolKind]?, tagSupport: [SymbolTag]?,
 		resolveSupport: Properties?
@@ -20,6 +32,7 @@ public struct WorkspaceSymbolClientCapabilities: Codable, Hashable, Sendable {
 		self.resolveSupport = resolveSupport
 	}
 
+	/// Creates an instance from property names.
 	public init(
 		dynamicRegistration: Bool?, symbolKind: [SymbolKind]?, tagSupport: [SymbolTag]?,
 		resolveSupport: [String]?
@@ -32,23 +45,35 @@ public struct WorkspaceSymbolClientCapabilities: Codable, Hashable, Sendable {
 	}
 }
 
+/// Server capabilities for `workspace/symbol`.
 public struct WorkspaceSymbolOptions: Codable, Hashable, Sendable {
+	/// Whether the server supports work done progress.
 	public var workDoneProgress: Bool?
+	/// Whether the server supports resolving additional information for a workspace symbol.
+	///
+	/// - Since: 3.17.0
 	public var resolveProvider: Bool?
 
+	/// Creates an instance from its parts.
 	public init(workDoneProgress: Bool? = nil, resolveProvider: Bool? = nil) {
 		self.workDoneProgress = workDoneProgress
 		self.resolveProvider = resolveProvider
 	}
 }
 
+/// Registration options for `workspace/symbol`.
 public typealias WorkspaceSymbolRegistrationOptions = WorkspaceSymbolOptions
 
+/// Parameters for the `workspace/symbol` request.
 public struct WorkspaceSymbolParams: Codable, Hashable, Sendable {
+	/// An optional work done progress token.
 	public var workDoneToken: ProgressToken?
+	/// An optional token for partial result progress.
 	public var partialResultToken: ProgressToken?
+	/// A query string to filter symbols by.
 	public var query: String
 
+	/// Creates an instance from its parts.
 	public init(
 		query: String, workDoneToken: ProgressToken? = nil, partialResultToken: ProgressToken? = nil
 	) {
@@ -58,13 +83,22 @@ public struct WorkspaceSymbolParams: Codable, Hashable, Sendable {
 	}
 }
 
+/// A special workspace symbol that supports partial document references.
+///
+/// - Since: 3.17.0
 public struct WorkspaceSymbol: Codable, Hashable, Sendable {
+	/// The name of this symbol.
 	public var name: String
+	/// The kind of this symbol.
 	public var kind: SymbolKind
+	/// Tags for this symbol.
 	public var tags: [SymbolTag]?
+	/// The location of this symbol (full location or just the containing document).
 	public var location: TwoTypeOption<Location, TextDocumentIdentifier>?
+	/// The name of the symbol containing this symbol, if any.
 	public var containerName: String?
 
+	/// Creates an instance from its parts.
 	public init(
 		name: String, kind: SymbolKind, tags: [SymbolTag]? = nil,
 		location: TwoTypeOption<Location, TextDocumentIdentifier>? = nil,
@@ -78,4 +112,5 @@ public struct WorkspaceSymbol: Codable, Hashable, Sendable {
 	}
 }
 
+/// The response type for `workspace/symbol`.
 public typealias WorkspaceSymbolResponse = TwoTypeOption<[SymbolInformation], [WorkspaceSymbol]>?

--- a/Sources/LanguageServerProtocol/Workspace/WillCreateFiles.swift
+++ b/Sources/LanguageServerProtocol/Workspace/WillCreateFiles.swift
@@ -1,23 +1,40 @@
 import Foundation
 
+/// Whether a file operation pattern matches a file or folder.
+///
+/// - Since: 3.16.0
 public enum FileOperationPatternKind: String, Codable, Hashable, Sendable {
+	/// The pattern matches a file only.
 	case file = "file"
+	/// The pattern matches a folder only.
 	case folder = "folder"
 }
 
+/// Matching options for a file operation pattern.
+///
+/// - Since: 3.16.0
 public struct FileOperationPatternOptions: Codable, Hashable, Sendable {
+	/// Whether the pattern should be matched ignoring case.
 	public var ignoreCase: Bool?
 
+	/// Creates an instance from its parts.
 	public init(ignoreCase: Bool? = nil) {
 		self.ignoreCase = ignoreCase
 	}
 }
 
+/// A pattern to describe in which file operation requests or notifications the server is interested in.
+///
+/// - Since: 3.16.0
 public struct FileOperationPattern: Codable, Hashable, Sendable {
+	/// The glob pattern to match.
 	public let glob: String
+	/// Whether to match files or folders with this pattern.
 	public let matches: FileOperationPatternKind?
+	/// Additional options for the pattern.
 	public let options: FileOperationPatternOptions?
 
+	/// Creates an instance from its parts.
 	public init(
 		glob: String, matches: FileOperationPatternKind?, options: FileOperationPatternOptions?
 	) {
@@ -27,38 +44,60 @@ public struct FileOperationPattern: Codable, Hashable, Sendable {
 	}
 }
 
+/// A filter to describe in which file operation requests or notifications the server is interested in.
+///
+/// - Since: 3.16.0
 public struct FileOperationFilter: Codable, Hashable, Sendable {
+	/// A URI scheme like `file` or `untitled`.
 	public var scheme: String?
+	/// The actual file operation pattern.
 	public var pattern: FileOperationPattern
 
+	/// Creates an instance from its parts.
 	public init(scheme: String? = nil, pattern: FileOperationPattern) {
 		self.scheme = scheme
 		self.pattern = pattern
 	}
 }
 
+/// Registration options for file operations.
+///
+/// - Since: 3.16.0
 public struct FileOperationRegistrationOptions: Codable, Hashable, Sendable {
+	/// The actual filters.
 	public var filters: [FileOperationFilter]
 
+	/// Creates an instance from its parts.
 	public init(filters: [FileOperationFilter]) {
 		self.filters = filters
 	}
 }
 
+/// Parameters for the `workspace/willCreateFiles` request.
+///
+/// - Since: 3.16.0
 public struct CreateFilesParams: Codable, Hashable, Sendable {
+	/// The files that are being created.
 	public var files: [FileCreate]
 
+	/// Creates an instance from its parts.
 	public init(files: [FileCreate]) {
 		self.files = files
 	}
 }
 
+/// Represents information on a file/folder create.
+///
+/// - Since: 3.16.0
 public struct FileCreate: Codable, Hashable, Sendable {
+	/// A `file://` URI for the location of the created file/folder.
 	public var uri: String
 
+	/// Creates an instance from its parts.
 	public init(uri: String) {
 		self.uri = uri
 	}
 }
 
+/// The response type for `workspace/willCreateFiles`.
 public typealias WorkspaceWillCreateFilesResponse = WorkspaceEdit?

--- a/Sources/LanguageServerProtocol/Workspace/WillDeleteFiles.swift
+++ b/Sources/LanguageServerProtocol/Workspace/WillDeleteFiles.swift
@@ -1,19 +1,30 @@
 import Foundation
 
+/// Parameters for the `workspace/willDeleteFiles` request.
+///
+/// - Since: 3.16.0
 public struct DeleteFilesParams: Codable, Hashable, Sendable {
+	/// The files that are being deleted.
 	public var files: [FileDelete]
 
+	/// Creates an instance from its parts.
 	public init(files: [FileDelete]) {
 		self.files = files
 	}
 }
 
+/// Represents information on a file/folder delete.
+///
+/// - Since: 3.16.0
 public struct FileDelete: Codable, Hashable, Sendable {
+	/// A `file://` URI for the location of the deleted file/folder.
 	public var uri: String
 
+	/// Creates an instance from its parts.
 	public init(uri: String) {
 		self.uri = uri
 	}
 }
 
+/// The response type for `workspace/willDeleteFiles`.
 public typealias WorkspaceWillDeleteFilesResponse = WorkspaceEdit?

--- a/Sources/LanguageServerProtocol/Workspace/WillRenameFiles.swift
+++ b/Sources/LanguageServerProtocol/Workspace/WillRenameFiles.swift
@@ -1,21 +1,33 @@
 import Foundation
 
+/// Parameters for the `workspace/willRenameFiles` request.
+///
+/// - Since: 3.16.0
 public struct RenameFilesParams: Codable, Hashable, Sendable {
+	/// The files that are being renamed.
 	public var files: [FileRename]
 
+	/// Creates an instance from its parts.
 	public init(files: [FileRename]) {
 		self.files = files
 	}
 }
 
+/// Represents information on a file/folder rename.
+///
+/// - Since: 3.16.0
 public struct FileRename: Codable, Hashable, Sendable {
+	/// A `file://` URI for the original location of the file/folder.
 	public var oldUri: String
+	/// A `file://` URI for the new location of the file/folder.
 	public var newUri: String
 
+	/// Creates an instance from its parts.
 	public init(oldUri: String, newUri: String) {
 		self.oldUri = oldUri
 		self.newUri = newUri
 	}
 }
 
+/// The response type for `workspace/willRenameFiles`.
 public typealias WorkspaceWillRenameFilesResponse = WorkspaceEdit?


### PR DESCRIPTION
As a frequent happy user of this library, I was missing API docs from declarations on this library, often browsing the specification on what certain properties are.

I used Claude Opus 4.6 Thinking with Windsurf to add in-source documentation to this library. I totally understand if this kind of contribution is not welcome, I just wanted to be upfront about it. I tried my best to ensure the quality of these docs, see my process below. If this is merged, I can also follow the same process for documenting LanguageServer.

I made the prompt based on [Hylo's coding conventions](https://github.com/hylo-lang/hylo-new/blob/16802fd7a5c820c1aa8ef65a64f3c7dd1701800d/CONVENTIONS.md) for documentation:

```md
You are asked to introduce documentation to this library strictly according to the official language server protocol specification at https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/ Please follow the guidelines defined below. Do not modify any API, only add the documentation comments.

Our conventions are based on the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).

Documentation enables local reasoning - it's a shortcut for understanding so readers can avoid looking up implementation
or usages to infer meaning.

- Every declaration outside a function body must have a documentation comment that describes its contract.
  - Start with a summary sentence fragment.
    - Describe what a function or method does and what it returns.
    - Describe what a property or type is.
    - Separate the fragment from any additional documentation with a blank line and end it with a period.

  - Preconditions, postconditions and invariants obviously implied by the summary need not be explicitly documented.

  - Declarations that fulfill protocol requirements are exempted when nothing useful can be added to the documentation
    of the protocol requirement itself.

- Document the performance of every operation that doesn't execute in constant time and space, unless it's obvious from
  the summary.
- Test cases need not be documented, but should have a descriptive function name.

- Phrasing conventions:
  - Omit needless words: don't repeat the receiver's type, don't write the, given, of self,
    of the current object when context makes these obvious.
  - Use iff instead of if where applicable.
  - Use <...>, if any. for optional values where the absence reason is obvious. Otherwise:
    <...> if <condition>, nil otherwise. 
  - Document preconditions with - Requires:. If multiple preconditions apply, use a markdown list below - Requires:.
- Conformance implementations are exempt from documentation when nothing useful can be added beyond the protocol
  requirement itself.
- For trivial constructors, use `/// Creates an instance from its parts.`
- Test cases don't need to be documented, but should have a descriptive function name.
- For types, the summary should say what the type *is*. For functions and subscripts, it should say what they *do* (e.g. returns, yields ...).
- Describe if there is a significance in the element order of an array.
```

After planning, it came up with the following plan:

<details>
<summary>Plan.md</summary>

```md
# Document the LanguageServerProtocol Library

Add documentation comments to all 42 source files following the LSP 3.17 specification and the project's documentation conventions.

## Conventions Summary

- Use `///` style (convert existing `/** */` comments)
- Summary sentence fragment describing what a type *is* or what a function *does*, ending with a period
- Trivial initializers: `/// Creates an instance from its parts.`
- Skip conformance extensions when nothing useful can be added
- Use LSP spec descriptions as the source of truth for semantic meaning, copying exact phrasing where possible.
- Follow phrasing conventions: omit needless words, use `iff` over `if`, `Returns ..., if any` for optionals.

## Batches

### Batch 1 – Base & Core Types
1. `BaseProtocol.swift` – typealiases (`LSPAny`, `URI`, `DocumentUri`, `ProgressToken`), `CancelParams`, `ProgressParams`, `LogTraceParams`, `TraceValue`, `SetTraceParams`, `ValueSet`, `LanguageIdentifier`, `DocumentFilter`, `DocumentSelector`, `TextDocumentIdentifier`
2. `BasicStructures.swift` – `Position`, `LSPRange`, `TextDocumentItem`, `VersionedTextDocumentIdentifier`, `Location`, `Command`, `SymbolKind`, `MarkupKind`, `TextDocumentPositionParams`, `LanguageStringPair`, `MarkedString`, `MarkupContent`, `LocationLink`
3. `TwoTypeOption.swift` – generic union type
4. `ThreeTypeOption.swift` – generic union type
5. `Utility.swift`
6. `ErrorCodes.swift` – convert existing `/** */` to `///`

### Batch 2 – Server Lifecycle & General
7. `General.swift` – `Tracing`, `InitializeParams`, `ServerInfo`, `InitializationResponse`, `InitializedParams`; convert existing `/** */`
8. `LanguageServerProtocol.swift` – `ProtocolError`, `ClientEvent`, `ServerEvent`, `ClientNotification`, `ClientRequest`, `ServerNotification`, `ServerRequest`
9. `Client.swift`
10. `ClientCapabilities.swift`
11. `ServerCapabilities.swift`

### Batch 3 – Text Synchronization & Window
12. `TextSynchronization.swift` – `TextDocumentSyncKind`, `DidOpenTextDocumentParams`, etc.
13. `Window.swift` – `MessageType`, `LogMessageParams`, `ShowMessageParams`, `ShowDocumentParams`, `WorkDoneProgressCreateParams`, `ShowDocumentResult`
14. `Window/ShowMessageRequest.swift` – `MessageActionItem`, `ShowMessageRequestParams`, `ShowMessageRequestResponse`

### Batch 4 – Workspace
15. `Workspace.swift`
16. `Workspace/ApplyEdit.swift`
17. `Workspace/Configuration.swift`
18. `Workspace/ExecuteCommand.swift`
19. `Workspace/Folders.swift`
20. `Workspace/Symbol.swift`
21. `Workspace/WillCreateFiles.swift`
22. `Workspace/WillDeleteFiles.swift`
23. `Workspace/WillRenameFiles.swift`

### Batch 5 – Language Features (A-D)
24. `LanguageFeatures/CallHeirarchy.swift`
25. `LanguageFeatures/CodeAction.swift`
26. `LanguageFeatures/CodeLens.swift`
27. `LanguageFeatures/ColorPresentation.swift`
28. `LanguageFeatures/Completion.swift`
29. `LanguageFeatures/Declaration.swift`
30. `LanguageFeatures/Definition.swift`
31. `LanguageFeatures/Diagnostics.swift`
32. `LanguageFeatures/DocumentColor.swift`
33. `LanguageFeatures/DocumentHighlight.swift`
34. `LanguageFeatures/DocumentLink.swift`
35. `LanguageFeatures/DocumentSymbol.swift`

### Batch 6 – Language Features (F-Z)
36. `LanguageFeatures/FoldingRange.swift`
37. `LanguageFeatures/Formatting.swift`
38. `LanguageFeatures/Hover.swift`
39. `LanguageFeatures/Implementation.swift`
40. `LanguageFeatures/InlayHint.swift`
41. `LanguageFeatures/LinkedEditingRange.swift`
42. `LanguageFeatures/Moniker.swift`
43. `LanguageFeatures/OnTypeFormatting.swift`
44. `LanguageFeatures/References.swift`
45. `LanguageFeatures/Rename.swift`
46. `LanguageFeatures/SelectionRange.swift`
47. `LanguageFeatures/SemanticTokens.swift`
48. `LanguageFeatures/SignatureHelp.swift`
49. `LanguageFeatures/TypeDefinition.swift`
50. `LanguageFeatures/TypeHeirarchy.swift`

### Batch 7 – Client & Framing & Additions
51. `Client/ServerConnection.swift`
52. `Client/JSONRPCServerConnection.swift`
53. `Client/MockServer.swift`
54. `Framing/AsyncByteSequence.swift`
55. `Framing/AsyncMessageFramingSequence.swift`
56. `Framing/DataChannel+MessageFraming.swift`
57. `Framing/MessageFraming.swift`
58. `Additions/AsyncStreamPolyfill.swift`
59. `Additions/NSRegularExpression+Matching.swift`
60. `Additions/Protocol+Mutating.swift`
61. `Additions/ServerCapabilities+Extensions.swift`
62. `Additions/Snippet.swift`
63. `Additions/TokenRepresentation.swift`

## Approach

- For each file, read the LSP spec section(s) relevant to the types in that file
- Write `///` doc comments on every public type, property, method, enum case, and typealias
- Use the spec's description as the basis but adapt phrasing to match Swift conventions
- Do not modify any API signatures, logic, or non-doc comments
- Run `swift test` after every batch.
```

</details>

## Review

### AI-assisted review
After completion, I executed a separate review of the documentation 2 times, during which it completed API documentation it missed previously, and corrected 3 comments that were slightly wordy or inaccurate.

### Manual review
After the AI-assisted review, I read through the PR quickly to see if there is anything obviously inaccurate/badly phrased. I noticed that it removed the `@since` tags from existing comments, so I run another pass to update them.

<details>
<summary>add `@since`</summary>

```
In the last commit, several comments mentioning the @since were removed. We need these 
information whenever the LSP doc mentions it. Please add them back where they were 
present before, and in addition, whenever the specification mentioned it explicitly.
```

</details>

I run another pass of AI-assisted review to check if the `- Since` annotations match up with the LSP specification's information. There were no inaccuracies found in this pass.