### PR TITLE
Add CompletionItem.labelDetails (LSP 3.17)

### DIFF
--- a/Sources/LanguageServerProtocol/LanguageFeatures/Completion.swift
+++ b/Sources/LanguageServerProtocol/LanguageFeatures/Completion.swift
@@ -155,8 +155,19 @@ public enum InsertTextFormat: Int, Codable, Hashable, Sendable {
 	case snippet = 2
 }
 
+public struct CompletionItemLabelDetails: Codable, Hashable, Sendable {
+	public let detail: String?
+	public let description: String?
+
+	public init(detail: String? = nil, description: String? = nil) {
+		self.detail = detail
+		self.description = description
+	}
+}
+
 public struct CompletionItem: Codable, Hashable, Sendable {
 	public let label: String
+	public let labelDetails: CompletionItemLabelDetails?
 	public let kind: CompletionItemKind?
 	public let detail: String?
 	public let documentation: TwoTypeOption<String, MarkupContent>?
@@ -174,6 +185,7 @@ public struct CompletionItem: Codable, Hashable, Sendable {
 
 	public init(
 		label: String,
+		labelDetails: CompletionItemLabelDetails? = nil,
 		kind: CompletionItemKind? = nil,
 		detail: String? = nil,
 		documentation: TwoTypeOption<String, MarkupContent>? = nil,
@@ -190,6 +202,7 @@ public struct CompletionItem: Codable, Hashable, Sendable {
 		data: LSPAny? = nil
 	) {
 		self.label = label
+		self.labelDetails = labelDetails
 		self.kind = kind
 		self.detail = detail
 		self.documentation = documentation

--- a/Tests/LanguageServerProtocolTests/CompletionItemTests.swift
+++ b/Tests/LanguageServerProtocolTests/CompletionItemTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+import LanguageServerProtocol
+
+final class CompletionItemTests: XCTestCase {
+	func testDecodingLabelDetails() throws {
+		// a textDocument/completion response item shaped per the LSP 3.17 spec
+		let json = """
+{"label":"map","labelDetails":{"detail":"(transform: (Element) -> T)","description":"[T]"},"kind":3,"insertText":"map"}
+"""
+		let data = try XCTUnwrap(json.data(using: .utf8))
+		let item = try JSONDecoder().decode(CompletionItem.self, from: data)
+
+		XCTAssertEqual(item.labelDetails, CompletionItemLabelDetails(detail: "(transform: (Element) -> T)", description: "[T]"))
+	}
+}

--- a/Tests/LanguageServerProtocolTests/CompletionItemTests.swift
+++ b/Tests/LanguageServerProtocolTests/CompletionItemTests.swift
@@ -5,8 +5,8 @@ final class CompletionItemTests: XCTestCase {
 	func testDecodingLabelDetails() throws {
 		// a textDocument/completion response item shaped per the LSP 3.17 spec
 		let json = """
-{"label":"map","labelDetails":{"detail":"(transform: (Element) -> T)","description":"[T]"},"kind":3,"insertText":"map"}
-"""
+            {"label":"map","labelDetails":{"detail":"(transform: (Element) -> T)","description":"[T]"},"kind":3,"insertText":"map"}
+            """
 		let data = try XCTUnwrap(json.data(using: .utf8))
 		let item = try JSONDecoder().decode(CompletionItem.self, from: data)
 


### PR DESCRIPTION
Adds `CompletionItemLabelDetails` and the corresponding `labelDetails` field on `CompletionItem` ([LSP 3.17 spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem)).

The client capability (`CompletionClientCapabilities.CompletionItem.labelDetailsSupport`) and the server capability (`CompletionOptions.CompletionItem.labelDetailsSupport`) are already modeled, but the item field itself was missing, so a server had no way to actually return label details. The field is optional and defaulted, so existing call sites are source-compatible, and it is omitted from the encoded JSON when absent.

Includes a test decoding a spec-shaped completion item with `labelDetails`.